### PR TITLE
Bmatsuo/reader list context fix

### DIFF
--- a/lmdb/bench_test.go
+++ b/lmdb/bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkEnv_ReaderList(b *testing.B) {
 		}
 	}()
 
-	const numreaders = 20
+	const numreaders = 100
 	for i := 0; i < numreaders; i++ {
 		txn, err := env.BeginTxn(nil, Readonly)
 		if err != nil {

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -117,7 +117,7 @@ func (env *Env) ReaderList(fn func(string) error) error {
 	ctx, done := newMsgFunc(fn)
 	defer done()
 
-	ret := C.lmdbgo_mdb_reader_list(env._env, unsafe.Pointer(ctx))
+	ret := C.lmdbgo_mdb_reader_list(env._env, C.size_t(ctx))
 	if ret >= 0 {
 		return nil
 	}

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -114,14 +114,16 @@ func (env *Env) FD() (uintptr, error) {
 //
 // See mdb_reader_list.
 func (env *Env) ReaderList(fn func(string) error) error {
-	ctx := newMsgCtx(fn)
+	ctx := registerMsgctx(fn)
+	defer ctx.deregister()
 	ret := C.lmdbgo_mdb_reader_list(env._env, unsafe.Pointer(ctx))
 	if ret >= 0 {
 		return nil
 	}
 	if ret < 0 {
-		if ctx.err != nil {
-			return ctx.err
+		err := ctx.err()
+		if err != nil {
+			return err
 		}
 	}
 	return operrno("mdb_reader_list", ret)

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -114,8 +114,9 @@ func (env *Env) FD() (uintptr, error) {
 //
 // See mdb_reader_list.
 func (env *Env) ReaderList(fn func(string) error) error {
-	ctx := registerMsgctx(fn)
-	defer ctx.deregister()
+	ctx, done := newMsgFunc(fn)
+	defer done()
+
 	ret := C.lmdbgo_mdb_reader_list(env._env, unsafe.Pointer(ctx))
 	if ret >= 0 {
 		return nil

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -122,7 +122,7 @@ func (env *Env) ReaderList(fn func(string) error) error {
 		return nil
 	}
 	if ret < 0 {
-		err := ctx.err()
+		err := ctx.get().err
 		if err != nil {
 			return err
 		}

--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -59,15 +59,9 @@ package lmdb
 #cgo openbsd CFLAGS: -DMDB_DSYNC=O_SYNC
 #cgo netbsd CFLAGS: -DMDB_DSYNC=O_SYNC
 
-#include <stdlib.h>
 #include "lmdb.h"
-#include "lmdbgo.h"
 */
 import "C"
-import (
-	"sync"
-	"unsafe"
-)
 
 // Version return the major, minor, and patch version numbers of the LMDB C
 // library and a string representation of the version.
@@ -91,82 +85,6 @@ func VersionString() string {
 func cbool(b bool) C.int {
 	if b {
 		return 1
-	}
-	return 0
-}
-
-// msgctx is the type used for context pointers passed to mdb_reader_list.  A
-// msgctx stores its corresponding msgfunc, and any error encountered in an
-// external map.  The corresponding function is called once for each
-// mdb_reader_list entry using the msgctx.
-//
-// External maps are required because struct pointers passed to C functions
-// must not contain pointers in their struct fields.  See the following
-// language proposal which discusses the restrictions on passing pointers to C.
-//
-//		https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md
-//
-// NOTE:
-// The underlying type must have a non-zero size to ensure that the value
-// returned by new(msgctx) does not conflict with other live *msgctx values.
-type msgctx byte
-type msgfunc func(string) error
-
-var msgctxm = map[*msgctx]msgfunc{}
-var msgctxe = map[*msgctx]error{}
-var msgctxmlock sync.RWMutex
-
-func registerMsgctx(fn msgfunc) *msgctx {
-	ctx := new(msgctx)
-	ctx.register(fn)
-	return ctx
-}
-
-func (ctx *msgctx) register(fn msgfunc) {
-	msgctxmlock.Lock()
-	msgctxm[ctx] = fn
-	msgctxmlock.Unlock()
-}
-
-func (ctx *msgctx) deregister() {
-	msgctxmlock.Lock()
-	delete(msgctxm, ctx)
-	delete(msgctxe, ctx)
-	msgctxmlock.Unlock()
-}
-
-func (ctx *msgctx) fn() msgfunc {
-	msgctxmlock.Lock()
-	fn := msgctxm[ctx]
-	msgctxmlock.Unlock()
-	return fn
-}
-
-func (ctx *msgctx) err() error {
-	msgctxmlock.Lock()
-	err := msgctxe[ctx]
-	msgctxmlock.Unlock()
-	return err
-}
-
-func (ctx *msgctx) seterr(err error) {
-	msgctxmlock.Lock()
-	msgctxe[ctx] = err
-	msgctxmlock.Unlock()
-}
-
-//export lmdbgoMDBMsgFuncBridge
-func lmdbgoMDBMsgFuncBridge(msg C.lmdbgo_ConstCString, _ctx unsafe.Pointer) C.int {
-	ctx := (*msgctx)(_ctx)
-	fn := ctx.fn()
-	if fn == nil {
-		return 0
-	}
-
-	err := fn(C.GoString(msg.p))
-	if err != nil {
-		ctx.seterr(err)
-		return -1
 	}
 	return 0
 }

--- a/lmdb/lmdbgo.c
+++ b/lmdb/lmdbgo.c
@@ -12,8 +12,8 @@ int lmdbgo_mdb_msg_func_proxy(const char *msg, void *ctx) {
     return lmdbgoMDBMsgFuncBridge(s, ctx);
 }
 
-int lmdbgo_mdb_reader_list(MDB_env *env, void *ctx) {
+int lmdbgo_mdb_reader_list(MDB_env *env, size_t ctx) {
     // list readers using a static proxy function that does dynamic dispatch on
     // ctx.
-    return mdb_reader_list(env, &lmdbgo_mdb_msg_func_proxy, ctx);
+    return mdb_reader_list(env, &lmdbgo_mdb_msg_func_proxy, (void *)ctx);
 }

--- a/lmdb/lmdbgo.c
+++ b/lmdb/lmdbgo.c
@@ -9,7 +9,7 @@ int lmdbgo_mdb_msg_func_proxy(const char *msg, void *ctx) {
     //  wrap msg and call the bridge function exported from lmdb.go.
     lmdbgo_ConstCString s;
     s.p = msg;
-    return lmdbgoMDBMsgFuncBridge(s, ctx);
+    return lmdbgoMDBMsgFuncBridge(s, (size_t)ctx);
 }
 
 int lmdbgo_mdb_reader_list(MDB_env *env, size_t ctx) {

--- a/lmdb/lmdbgo.h
+++ b/lmdb/lmdbgo.h
@@ -16,6 +16,6 @@ typedef struct{ const char *p; } lmdbgo_ConstCString;
  * mdb_msg_func proxy function to relay messages over the
  * lmdbgo_mdb_reader_list_bridge external Go func.
  * */
-int lmdbgo_mdb_reader_list(MDB_env *env, void *ctx);
+int lmdbgo_mdb_reader_list(MDB_env *env, size_t ctx);
 
 #endif

--- a/lmdb/msgfunc.go
+++ b/lmdb/msgfunc.go
@@ -1,0 +1,87 @@
+package lmdb
+
+/*
+#include <stdlib.h>
+#include "lmdbgo.h"
+*/
+import "C"
+import (
+	"sync"
+	"unsafe"
+)
+
+// msgctx is the type used for context pointers passed to mdb_reader_list.  A
+// msgctx stores its corresponding msgfunc, and any error encountered in an
+// external map.  The corresponding function is called once for each
+// mdb_reader_list entry using the msgctx.
+//
+// External maps are required because struct pointers passed to C functions
+// must not contain pointers in their struct fields.  See the following
+// language proposal which discusses the restrictions on passing pointers to C.
+//
+//		https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md
+//
+// NOTE:
+// The underlying type must have a non-zero size to ensure that the value
+// returned by new(msgctx) does not conflict with other live *msgctx values.
+type msgctx byte
+type msgfunc func(string) error
+
+var msgctxm = map[*msgctx]msgfunc{}
+var msgctxe = map[*msgctx]error{}
+var msgctxmlock sync.RWMutex
+
+func newMsgFunc(fn msgfunc) (ctx *msgctx, done func()) {
+	ctx = new(msgctx)
+	ctx.register(fn)
+	return ctx, ctx.deregister
+}
+
+func (ctx *msgctx) register(fn msgfunc) {
+	msgctxmlock.Lock()
+	msgctxm[ctx] = fn
+	msgctxmlock.Unlock()
+}
+
+func (ctx *msgctx) deregister() {
+	msgctxmlock.Lock()
+	delete(msgctxm, ctx)
+	delete(msgctxe, ctx)
+	msgctxmlock.Unlock()
+}
+
+func (ctx *msgctx) fn() msgfunc {
+	msgctxmlock.Lock()
+	fn := msgctxm[ctx]
+	msgctxmlock.Unlock()
+	return fn
+}
+
+func (ctx *msgctx) err() error {
+	msgctxmlock.Lock()
+	err := msgctxe[ctx]
+	msgctxmlock.Unlock()
+	return err
+}
+
+func (ctx *msgctx) seterr(err error) {
+	msgctxmlock.Lock()
+	msgctxe[ctx] = err
+	msgctxmlock.Unlock()
+}
+
+//export lmdbgoMDBMsgFuncBridge
+func lmdbgoMDBMsgFuncBridge(msg C.lmdbgo_ConstCString, _ctx unsafe.Pointer) C.int {
+	ctx := (*msgctx)(_ctx)
+	fn := ctx.fn()
+	if fn == nil {
+		return 0
+	}
+
+	err := fn(C.GoString(msg.p))
+	if err != nil {
+		ctx.seterr(err)
+		return -1
+	}
+	return 0
+}

--- a/lmdb/msgfunc.go
+++ b/lmdb/msgfunc.go
@@ -37,15 +37,11 @@ type msgfunc func(string) error
 // external map.  The corresponding function is called once for each
 // mdb_reader_list entry using the msgctx.
 //
-// External maps are required because struct pointers passed to C functions
-// must not contain pointers in their struct fields.  See the following
-// language proposal which discusses the restrictions on passing pointers to C.
+// An External map is used because struct pointers passed to C functions must
+// not contain pointers in their struct fields.  See the following language
+// proposal which discusses the restrictions on passing pointers to C.
 //
 //		https://github.com/golang/proposal/blob/master/design/12416-cgo-pointers.md
-//
-// NOTE:
-// The underlying type must have a non-zero size to ensure that the value
-// returned by new(msgctx) does not conflict with other live *msgctx values.
 type msgctx uintptr
 type _msgctx struct {
 	fn  msgfunc


### PR DESCRIPTION
Relates to #10.

Stops passing a struct containing a function pointer through a C function. The function pointer is stored in a map along with any error returned by the `msgfunc`.

A simple benchmark was added for Env.ReaderList to gauge performance previously and with the given changes. One hundred readers are listed on an empty environment:

before:
```
PASS
BenchmarkEnv_ReaderList-4	   20000	     73322 ns/op
ok  	github.com/bmatsuo/lmdb-go/lmdb	2.756s
```

after:
```
PASS
BenchmarkEnv_ReaderList-4	   20000	     72888 ns/op
ok  	github.com/bmatsuo/lmdb-go/lmdb	2.701s
```

benchcmp: 
```
benchmark                     old ns/op     new ns/op     delta
BenchmarkEnv_ReaderList-4     73322         72888         -0.59%
```