### PR TITLE
Bmatsuo/lmdbscan set calls get

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ Core bindings allowing low-level access to LMDB.
 import "github.com/bmatsuo/lmdb-go/exp/lmdbscan"
 ```
 
-A utility package for scanning database ranges with an API inspired by
-[bufio.Scanner](https://godoc.org/bufio#Scanner).
+A utility package for scanning database ranges. The API is inspired by
+[bufio.Scanner](https://godoc.org/bufio#Scanner) and the python cursor iterator
+implementation.
 
 The **lmdbscan** package is unstable. The API is properly scoped and adequately
 tested.  And no features that exist now will be removed without a similar
@@ -43,7 +44,8 @@ import "github.com/bmatsuo/lmdb-go/exp/lmdbsync"
 ```
 
 An experimental utility package that provides synchronization necessary to
-change an environment's map size after initialization.
+change an environment's map size after initialization.  Facilities are provided
+to automatically manage database size, similar to BoltDB.
 
 The **lmdbsync** package is usable for synchronization but its resizing
 behavior should be considered highly unstable and may change without notice

--- a/exp/lmdbscan/example_test.go
+++ b/exp/lmdbscan/example_test.go
@@ -9,15 +9,14 @@ import (
 )
 
 var env *lmdb.Env
+var dbi lmdb.DBI
 
-// This example demonstrates basic usage of a Scanner to scan the root
-// database.  It is important to always call scanner.Err() which will returned
-// any unexpected error which interrupted scanner.Scan().
+// This example demonstrates basic usage of a Scanner to scan a database.  It
+// is important to always call scanner.Err() which will returned any unexpected
+// error which interrupted scanner.Scan().
 func ExampleScanner() {
 	err := env.View(func(txn *lmdb.Txn) (err error) {
-		dbroot, _ := txn.OpenRoot(0)
-
-		scanner := lmdbscan.New(txn, dbroot)
+		scanner := lmdbscan.New(txn, dbi)
 		defer scanner.Close()
 
 		for scanner.Scan() {
@@ -30,14 +29,12 @@ func ExampleScanner() {
 	}
 }
 
-// This example demonstrates scanning a key range in the root database.  Set is
-// used to move the cursor's starting position to the desired prefix.
+// This example demonstrates scanning a key range in a database.  Set is used
+// to move the cursor's starting position to the desired prefix.
 func ExampleScanner_Set() {
 	keyprefix := []byte("users:")
 	err := env.View(func(txn *lmdb.Txn) (err error) {
-		dbroot, _ := txn.OpenRoot(0)
-
-		scanner := lmdbscan.New(txn, dbroot)
+		scanner := lmdbscan.New(txn, dbi)
 		defer scanner.Close()
 
 		scanner.Set(keyprefix, nil, lmdb.SetRange)
@@ -61,14 +58,74 @@ func ExampleScanner_Set() {
 func ExampleScanner_SetNext() {
 	key := []byte("userphone:123")
 	err := env.View(func(txn *lmdb.Txn) (err error) {
-		dbroot, _ := txn.OpenRoot(0)
-
-		scanner := lmdbscan.New(txn, dbroot)
+		scanner := lmdbscan.New(txn, dbi)
 		defer scanner.Close()
 
 		scanner.SetNext(key, nil, lmdb.GetBothRange, lmdb.NextDup)
 		for scanner.Scan() {
 			log.Printf("k=%q v=%q", scanner.Key(), scanner.Val())
+		}
+		return scanner.Err()
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// This example demonstrates scanning all values for duplicate keys in a
+// database with the lmdb.DupSort flag set.  Two loops are used to iterate over
+// unique keys and their values respectively.  The example exploits the return
+// value from SetNext as the termination condition for the first loop.
+func ExampleScanner_SetNext_nextNoDup() {
+	err := env.View(func(txn *lmdb.Txn) (err error) {
+		scanner := lmdbscan.New(txn, dbi)
+		defer scanner.Close()
+
+		for scanner.SetNext(nil, nil, lmdb.NextNoDup, lmdb.NextDup) {
+			key := scanner.Key()
+			var vals [][]byte
+			for scanner.Scan() {
+				vals = append(vals, scanner.Val())
+			}
+			log.Printf("k=%q v=%q", key, vals)
+			if scanner.Err() != nil {
+				break
+			}
+		}
+		return scanner.Err()
+	})
+	if err != nil {
+		panic(err)
+	}
+}
+
+// This advanced example demonstrates batch scanning of values for duplicate
+// keys in a database with the lmdb.DupFixed and lmdb.DupSort flags set.  The
+// outer loop scans unique keys and the inner loop scans duplicate values.  The
+// GetMultiple op requires an additional check following its use to determine
+// if no duplicates exist in the database.
+func ExampleScanner_SetNext_getMultiple() {
+	err := env.View(func(txn *lmdb.Txn) (err error) {
+		scanner := lmdbscan.New(txn, dbi)
+		defer scanner.Close()
+
+		for scanner.Set(nil, nil, lmdb.NextNoDup) {
+			key := scanner.Key()
+			valFirst := scanner.Val()
+			var vals [][]byte
+			if !scanner.SetNext(nil, nil, lmdb.GetMultiple, lmdb.NextMultiple) {
+				// only one value exists for the key, and it has been scanned.
+				vals = append(vals, valFirst)
+			}
+			for scanner.Scan() {
+				// this loop is only entered if multiple values exist for key.
+				multi := lmdb.WrapMulti(scanner.Val(), len(valFirst))
+				vals = append(vals, multi.Vals()...)
+			}
+			log.Printf("k=%q v=%q", key, vals)
+			if scanner.Err() != nil {
+				break
+			}
 		}
 		return scanner.Err()
 	})

--- a/exp/lmdbscan/scanner_test.go
+++ b/exp/lmdbscan/scanner_test.go
@@ -23,6 +23,12 @@ func TestScanner_err(t *testing.T) {
 		for scanner.Scan() {
 			t.Error("loop should not execute")
 		}
+		if scanner.Set(nil, nil, lmdb.First) {
+			t.Error("Set returned true")
+		}
+		if scanner.SetNext(nil, nil, lmdb.NextNoDup, lmdb.NextDup) {
+			t.Error("SetNext returned true")
+		}
 		return scanner.Err()
 	})
 	if !lmdb.IsErrnoSys(err, syscall.EINVAL) {


### PR DESCRIPTION
Fixes #17.

The Scanner.Set and Scanner.SetNext methods actually call Cursor.Get to
prepare for the next call to Scanner.Scan, which becomes a noop.  The
return value added to the methods should allow more concise
representation of complex scanning behaviors.

Most existing code should behave the same.  Code will not behave
correctly if Scanner.Key, Scanner.Val, or Scanner.Err are accessed
following a call to Scanner.Set, expecting to retrieve values from a
preceding call to Scanner.Scan.