### PR TITLE
all: internal test package lmdbtest that performs common test tasks

### DIFF
--- a/exp/lmdbscan/scanner_test.go
+++ b/exp/lmdbscan/scanner_test.go
@@ -1,12 +1,11 @@
 package lmdbscan
 
 import (
-	"io/ioutil"
-	"os"
 	"reflect"
 	"syscall"
 	"testing"
 
+	"github.com/bmatsuo/lmdb-go/internal/lmdbtest"
 	"github.com/bmatsuo/lmdb-go/lmdb"
 )
 
@@ -15,9 +14,13 @@ type errcheck func(err error) (ok bool)
 var pIsNil = func(err error) bool { return err == nil }
 
 func TestScanner_err(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	err := env.View(func(txn *lmdb.Txn) (err error) {
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	err = env.View(func(txn *lmdb.Txn) (err error) {
 		scanner := New(txn, 123)
 		defer scanner.Close()
 		for scanner.Scan() {
@@ -31,9 +34,13 @@ func TestScanner_err(t *testing.T) {
 }
 
 func TestScanner_closed(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	err := env.View(func(txn *lmdb.Txn) (err error) {
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	err = env.View(func(txn *lmdb.Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -59,9 +66,13 @@ func TestScanner_closed(t *testing.T) {
 }
 
 func TestScanner_Scan(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -71,7 +82,7 @@ func TestScanner_Scan(t *testing.T) {
 	}
 	loadTestData(t, env, items)
 	for i, test := range []struct {
-		filtered []simpleitem
+		filtered lmdbtest.SimpleItemList
 		errcheck
 	}{
 		{
@@ -90,9 +101,13 @@ func TestScanner_Scan(t *testing.T) {
 }
 
 func TestScanner_Set(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -101,8 +116,8 @@ func TestScanner_Set(t *testing.T) {
 		{"k5", "v5"},
 	}
 	loadTestData(t, env, items)
-	var tail []simpleitem
-	err := env.View(func(txn *lmdb.Txn) (err error) {
+	var tail lmdbtest.SimpleItemList
+	err = env.View(func(txn *lmdb.Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -123,9 +138,13 @@ func TestScanner_Set(t *testing.T) {
 }
 
 func TestScanner_SetNext(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -134,8 +153,8 @@ func TestScanner_SetNext(t *testing.T) {
 		{"k5", "v5"},
 	}
 	loadTestData(t, env, items)
-	var head []simpleitem
-	err := env.View(func(txn *lmdb.Txn) (err error) {
+	var head lmdbtest.SimpleItemList
+	err = env.View(func(txn *lmdb.Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -163,9 +182,13 @@ func TestScanner_SetNext(t *testing.T) {
 }
 
 func TestScanner_Del(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -175,7 +198,7 @@ func TestScanner_Del(t *testing.T) {
 	}
 	loadTestData(t, env, items)
 	var dbi lmdb.DBI
-	err := env.Update(func(txn *lmdb.Txn) (err error) {
+	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -194,7 +217,7 @@ func TestScanner_Del(t *testing.T) {
 		t.Error(err)
 	}
 
-	var rem []simpleitem
+	var rem lmdbtest.SimpleItemList
 	err = env.View(func(txn *lmdb.Txn) (err error) {
 		s := New(txn, dbi)
 		defer s.Close()
@@ -211,9 +234,13 @@ func TestScanner_Del(t *testing.T) {
 }
 
 func TestScanner_Del_closed(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -223,7 +250,7 @@ func TestScanner_Del_closed(t *testing.T) {
 	}
 	loadTestData(t, env, items)
 	var dbi lmdb.DBI
-	err := env.Update(func(txn *lmdb.Txn) (err error) {
+	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -238,9 +265,13 @@ func TestScanner_Del_closed(t *testing.T) {
 }
 
 func TestScanner_Cursor_Del(t *testing.T) {
-	path, env := testEnv(t)
-	defer os.RemoveAll(path)
-	items := []simpleitem{
+	env, err := lmdbtest.NewEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env)
+
+	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
 		{"k2", "v2"},
@@ -250,7 +281,7 @@ func TestScanner_Cursor_Del(t *testing.T) {
 	}
 	loadTestData(t, env, items)
 	var dbi lmdb.DBI
-	err := env.Update(func(txn *lmdb.Txn) (err error) {
+	err = env.Update(func(txn *lmdb.Txn) (err error) {
 		dbi, err = txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -270,7 +301,7 @@ func TestScanner_Cursor_Del(t *testing.T) {
 		t.Error(err)
 	}
 
-	var rem []simpleitem
+	var rem lmdbtest.SimpleItemList
 	err = env.View(func(txn *lmdb.Txn) (err error) {
 		s := New(txn, dbi)
 		defer s.Close()
@@ -288,26 +319,19 @@ func TestScanner_Cursor_Del(t *testing.T) {
 
 type simpleitem [2]string
 
-func loadTestData(t *testing.T, env *lmdb.Env, items []simpleitem) {
-	err := env.Update(func(txn *lmdb.Txn) (err error) {
-		db, err := txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
-		for _, item := range items {
-			err := txn.Put(db, []byte(item[0]), []byte(item[1]), 0)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+func loadTestData(t *testing.T, env *lmdb.Env, items lmdbtest.ItemList) {
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	err = lmdbtest.Put(env, dbi, items)
 	if err != nil {
 		t.Error(err)
 	}
 }
 
-func simplescan(env *lmdb.Env) (items []simpleitem, err error) {
+func simplescan(env *lmdb.Env) (items lmdbtest.SimpleItemList, err error) {
 	err = env.View(func(txn *lmdb.Txn) (err error) {
 		db, err := txn.OpenRoot(0)
 		if err != nil {
@@ -323,35 +347,17 @@ func simplescan(env *lmdb.Env) (items []simpleitem, err error) {
 	return items, err
 }
 
-func remaining(s *Scanner) (items []simpleitem, err error) {
+func remaining(s *Scanner) (items lmdbtest.SimpleItemList, err error) {
 	for s.Scan() {
-		items = append(items, simpleitem{string(s.Key()), string(s.Val())})
+		item := &lmdbtest.SimpleItem{
+			K: string(s.Key()),
+			V: string(s.Val()),
+		}
+		items = append(items, item)
 	}
 	err = s.Err()
 	if err != nil {
 		return nil, err
 	}
 	return items, nil
-}
-
-func testEnv(t *testing.T) (path string, env *lmdb.Env) {
-	dir, err := ioutil.TempDir("", "test-lmdb-env-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cleanAndDie := func() {
-		os.RemoveAll(dir)
-		t.Fatal(err)
-	}
-
-	env, err = lmdb.NewEnv()
-	if err != nil {
-		cleanAndDie()
-	}
-	err = env.Open(dir, 0, 0644)
-	if err != nil {
-		cleanAndDie()
-	}
-
-	return dir, env
 }

--- a/exp/lmdbscan/scanner_test.go
+++ b/exp/lmdbscan/scanner_test.go
@@ -72,6 +72,12 @@ func TestScanner_Scan(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -80,23 +86,16 @@ func TestScanner_Scan(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
-	for i, test := range []struct {
-		filtered lmdbtest.SimpleItemList
-		errcheck
-	}{
-		{
-			items,
-			nil,
-		},
-	} {
-		filtered, err := simplescan(env)
-		if err != nil {
-			t.Errorf("test %d: %v", i, err)
-		}
-		if !reflect.DeepEqual(filtered, test.filtered) {
-			t.Errorf("test %d: unexpected items %q (!= %q)", i, filtered, test.filtered)
-		}
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+	scanned, err := simplescan(env, dbi)
+	if err != nil {
+		t.Errorf("%v", err)
+	}
+	if !reflect.DeepEqual(scanned, items) {
+		t.Errorf("unexpected items %q (!= %q)", scanned, items)
 	}
 }
 
@@ -107,6 +106,12 @@ func TestScanner_Set(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -115,7 +120,11 @@ func TestScanner_Set(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+
 	var tail lmdbtest.SimpleItemList
 	err = env.View(func(txn *lmdb.Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
@@ -144,6 +153,12 @@ func TestScanner_SetNext(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -152,7 +167,11 @@ func TestScanner_SetNext(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+
 	var head lmdbtest.SimpleItemList
 	err = env.View(func(txn *lmdb.Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
@@ -188,6 +207,12 @@ func TestScanner_Del(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -196,13 +221,12 @@ func TestScanner_Del(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
-	var dbi lmdb.DBI
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
-		dbi, err = txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
 		s := New(txn, dbi)
 		defer s.Close()
 		for s.Scan() {
@@ -240,6 +264,12 @@ func TestScanner_Del_closed(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -248,13 +278,12 @@ func TestScanner_Del_closed(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
-	var dbi lmdb.DBI
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
-		dbi, err = txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
 		s := New(txn, dbi)
 		s.Close()
 		return s.Del(0)
@@ -271,6 +300,12 @@ func TestScanner_Cursor_Del(t *testing.T) {
 	}
 	defer lmdbtest.Destroy(env)
 
+	dbi, err := lmdbtest.OpenRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 	items := lmdbtest.SimpleItemList{
 		{"k0", "v0"},
 		{"k1", "v1"},
@@ -279,13 +314,12 @@ func TestScanner_Cursor_Del(t *testing.T) {
 		{"k4", "v4"},
 		{"k5", "v5"},
 	}
-	loadTestData(t, env, items)
-	var dbi lmdb.DBI
+	err = lmdbtest.Put(env, dbi, items)
+	if err != nil {
+		t.Error(err)
+	}
+
 	err = env.Update(func(txn *lmdb.Txn) (err error) {
-		dbi, err = txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
 		s := New(txn, dbi)
 		defer s.Close()
 		cur := s.Cursor()
@@ -317,28 +351,9 @@ func TestScanner_Cursor_Del(t *testing.T) {
 	}
 }
 
-type simpleitem [2]string
-
-func loadTestData(t *testing.T, env *lmdb.Env, items lmdbtest.ItemList) {
-	dbi, err := lmdbtest.OpenRoot(env, 0)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	err = lmdbtest.Put(env, dbi, items)
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func simplescan(env *lmdb.Env) (items lmdbtest.SimpleItemList, err error) {
+func simplescan(env *lmdb.Env, dbi lmdb.DBI) (items lmdbtest.SimpleItemList, err error) {
 	err = env.View(func(txn *lmdb.Txn) (err error) {
-		db, err := txn.OpenRoot(0)
-		if err != nil {
-			return err
-		}
-
-		s := New(txn, db)
+		s := New(txn, dbi)
 		defer s.Close()
 
 		items, err = remaining(s)

--- a/exp/lmdbsync/handler_test.go
+++ b/exp/lmdbsync/handler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bmatsuo/lmdb-go/internal/lmdbtest"
 	"github.com/bmatsuo/lmdb-go/lmdb"
 )
 
@@ -22,8 +23,12 @@ func (h *testHandler) HandleTxnErr(b Bag, err error) (Bag, error) {
 }
 
 func TestHandlerChain(t *testing.T) {
-	env := newEnv(t, 0)
-	defer cleanEnv(t, env)
+	env, err := newEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env.Env)
+
 	b := bagWithEnv(Background(), env)
 
 	var chain1 HandlerChain
@@ -62,8 +67,11 @@ func (*passthroughHandler) HandleTxnErr(b Bag, err error) (Bag, error) {
 }
 
 func TestMapFullHandler(t *testing.T) {
-	env := newEnv(t, 0)
-	defer cleanEnv(t, env)
+	env, err := newEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env.Env)
 
 	info, err := env.Info()
 	if err != nil {
@@ -105,14 +113,17 @@ func TestMapFullHandler(t *testing.T) {
 }
 
 func TestMapResizedHandler(t *testing.T) {
-	env := newEnv(t, 0)
-	defer cleanEnv(t, env)
+	env, err := newEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lmdbtest.Destroy(env.Env)
 
 	b := bagWithEnv(Background(), env)
 	handler := MapResizedHandler(2, func(int) time.Duration { return 100 * time.Microsecond })
 
 	errother := fmt.Errorf("testerr")
-	_, err := handler.HandleTxnErr(b, errother)
+	_, err = handler.HandleTxnErr(b, errother)
 
 	errmapresized := &lmdb.OpError{
 		Op:    "lmdbsync_test_op",

--- a/internal/lmdbtest/lmdbtest.go
+++ b/internal/lmdbtest/lmdbtest.go
@@ -1,0 +1,160 @@
+package lmdbtest
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/bmatsuo/lmdb-go/lmdb"
+)
+
+// ItemList is a list of database items.
+type ItemList interface {
+	Len() int
+	Item(i int) Item
+}
+
+// EnvOptions specifies an environment configuration for a test involving an
+// LMDB database.
+type EnvOptions struct {
+	MaxReaders int
+	MaxDBs     int
+	MapSize    int64
+	Flags      uint
+}
+
+// NewEnv returns a test environment with the given options at a temporary
+// path.
+func NewEnv(opt *EnvOptions) (env *lmdb.Env, err error) {
+	var dir string
+	defer func() {
+		if err != nil {
+			if env != nil {
+				env.Close()
+			}
+			if dir != "" {
+				os.RemoveAll(dir)
+			}
+		}
+	}()
+
+	dir, err = ioutil.TempDir("", "lmdbtest-env-")
+	if err != nil {
+		return nil, err
+	}
+	env, err = lmdb.NewEnv()
+	if err != nil {
+		return nil, err
+	}
+	if opt != nil {
+		if opt.MaxReaders != 0 {
+			err = env.SetMaxReaders(opt.MaxReaders)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if opt.MaxDBs != 0 {
+			err = env.SetMaxDBs(opt.MaxDBs)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if opt.MapSize != 0 {
+			err = env.SetMapSize(opt.MapSize)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	err = env.Open(dir, 0, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	return env, nil
+}
+
+// Destroy closes env and removes its directory from the file system.
+func Destroy(env *lmdb.Env) {
+	if env == nil {
+		return
+	}
+	path, _ := env.Path()
+	env.Close()
+	if path != "" {
+		os.RemoveAll(path)
+	}
+}
+
+// OpenDBI is a helper that opens a transaction, opens the named database,
+// commits the transaction, and returns the open DBI handle to the caller.
+func OpenDBI(env *lmdb.Env, name string, flags uint) (lmdb.DBI, error) {
+	var dbi lmdb.DBI
+	err := env.Update(func(txn *lmdb.Txn) (err error) {
+		dbi, err = txn.OpenDBI(name, flags)
+		return err
+	})
+	return dbi, err
+}
+
+// OpenRoot is a helper that opens a transaction, opens the root database,
+// commits the transaction, and returns the open DBI handle to the caller.
+func OpenRoot(env *lmdb.Env, flags uint) (lmdb.DBI, error) {
+	var dbi lmdb.DBI
+	err := env.Update(func(txn *lmdb.Txn) (err error) {
+		dbi, err = txn.OpenRoot(flags)
+		return err
+	})
+	return dbi, err
+}
+
+// Put writes items to the handle dbi in env.
+func Put(env *lmdb.Env, dbi lmdb.DBI, items ItemList) error {
+	return env.Update(func(txn *lmdb.Txn) (err error) {
+		for i, n := 0, items.Len(); i < n; i++ {
+			item := items.Item(i)
+			err = txn.Put(dbi, item.Key(), item.Val(), 0)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// Item is an interface for database items.
+type Item interface {
+	Key() []byte
+	Val() []byte
+}
+
+// SimpleItemList is an ItemList
+type SimpleItemList []*SimpleItem
+
+// Len implements the ItemList interface.
+func (items SimpleItemList) Len() int { return len(items) }
+
+// Item implements the ItemList interface.
+func (items SimpleItemList) Item(i int) Item { return items[i] }
+
+// SimpleItem is a simple representation of a database item.
+type SimpleItem struct {
+	K string
+	V string
+}
+
+// Key implements Item interface.
+func (i *SimpleItem) Key() []byte { return []byte(i.K) }
+
+// Val implements the Item interface.
+func (i *SimpleItem) Val() []byte { return []byte(i.V) }
+
+// Len implements the ItemList interface
+func (i *SimpleItem) Len() int { return 1 }
+
+// Item implements the ItemList interface
+func (i *SimpleItem) Item(j int) Item {
+	if j != 0 {
+		panic("index out of range")
+	}
+	return i
+}


### PR DESCRIPTION
Fixes #24

Logic that was either repeated or is likely to be repeated was subsumed
into the new package.  The exp/lmdbscan and exp/lmdbsync packages have
had their tests converted to use the new package.

It's unclear if the core lmdb package can make use  of these helper
functions.  It is possible that, if a "black box" test style is used,
the internal package can be successfully imported.  But it is likely
that setup/teardown functions will need to remain defined in that
package.