### PR TITLE
lmdb: adds a runtime finalizer to Env to reclaim memory

### DIFF
--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -69,12 +69,13 @@ type Env struct {
 //
 // See mdb_env_create.
 func NewEnv() (*Env, error) {
-	var _env *C.MDB_env
-	ret := C.mdb_env_create(&_env)
+	env := new(Env)
+	ret := C.mdb_env_create(&env._env)
 	if ret != success {
 		return nil, operrno("mdb_env_create", ret)
 	}
-	return &Env{_env}, nil
+	runtime.SetFinalizer(env, (*Env).Close)
+	return env, nil
 }
 
 // Open an environment handle. If this function fails Close() must be called to


### PR DESCRIPTION
The NewEnv function calls runtime.SetFinalizer the returned Env to
ensure that its Close method is called before garbage collection, when
its C-managed memory would otherwise leak.