### PR TITLE
lmdb: adds finalizer to unmanaged Txn objects, aborting them before gc

### DIFF
--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -11,7 +11,6 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"runtime"
 	"unsafe"
@@ -378,7 +377,7 @@ func (env *Env) BeginTxn(parent *Txn, flags uint) (*Txn, error) {
 	if txn != nil {
 		runtime.SetFinalizer(txn, func(txn *Txn) {
 			if txn._txn != nil {
-				log.Printf("lmdb: aborting unreachable transaction %#x", uintptr(unsafe.Pointer(txn)))
+				txn.errf("lmdb: aborting unreachable transaction %#x", uintptr(unsafe.Pointer(txn)))
 				txn.Abort()
 			}
 		})

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -49,20 +49,16 @@ type Txn struct {
 // beginTxn does not lock the OS thread which is a prerequisite for creating a
 // write transaction.
 func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
-	var _txn *C.MDB_txn
+	txn := &Txn{env: env}
 	var ptxn *C.MDB_txn
 	if parent == nil {
 		ptxn = nil
 	} else {
 		ptxn = parent._txn
 	}
-	ret := C.mdb_txn_begin(env._env, ptxn, C.uint(flags), &_txn)
+	ret := C.mdb_txn_begin(env._env, ptxn, C.uint(flags), &txn._txn)
 	if ret != success {
 		return nil, operrno("mdb_txn_begin", ret)
-	}
-	txn := &Txn{
-		env:  env,
-		_txn: _txn,
 	}
 	return txn, nil
 }

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -39,9 +39,13 @@ func TestTxn_finalizer(t *testing.T) {
 		}
 	}()
 
+	// make sure that finalizer has a chance to get called.  it seems like this
+	// may not be consistent across versions of go.
 	runtime.GC()
 	runtime.Gosched()
-	time.Sleep(100 * time.Nanosecond)
+	time.Sleep(500 * time.Nanosecond)
+	runtime.GC()
+	runtime.Gosched()
 
 	if !called {
 		t.Errorf("error logging function was not called")

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -912,6 +912,72 @@ func BenchmarkTxn_ro(b *testing.B) {
 	}
 }
 
+func BenchmarkTxn_unmanaged_abort(b *testing.B) {
+	env := setup(b)
+	path, err := env.Path()
+	if err != nil {
+		env.Close()
+		b.Error(err)
+		return
+	}
+	defer os.RemoveAll(path)
+	defer env.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txn, err := env.BeginTxn(nil, 0)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		txn.Abort()
+	}
+}
+
+func BenchmarkTxn_unmanaged_commit(b *testing.B) {
+	env := setup(b)
+	path, err := env.Path()
+	if err != nil {
+		env.Close()
+		b.Error(err)
+		return
+	}
+	defer os.RemoveAll(path)
+	defer env.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txn, err := env.BeginTxn(nil, 0)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		txn.Abort()
+	}
+}
+
+func BenchmarkTxn_unmanaged_ro(b *testing.B) {
+	env := setup(b)
+	path, err := env.Path()
+	if err != nil {
+		env.Close()
+		b.Error(err)
+		return
+	}
+	defer os.RemoveAll(path)
+	defer env.Close()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		txn, err := env.BeginTxn(nil, Readonly)
+		if err != nil {
+			b.Error(err)
+			return
+		}
+		txn.Abort()
+	}
+}
+
 func BenchmarkTxn_renew(b *testing.B) {
 	env := setup(b)
 	path, err := env.Path()


### PR DESCRIPTION
Fixes #27

Txn objects created by the Env.BeginTxn method now have a finalizer than
aborts them if they become unreachable before being committed.  Aside
from freeing memory this can help databases from growing indefinitely
and can also unlock an environment from a lost write transaction.  These
benefits are new for unmanaged transactions.  Managed transactions have
never had such shortcomings.

These benchmark comparisons should be taken with a grain of salt.  There
are some unexplained big swings.  But unmanaged transactions do not
appear to have a significant performance impact.  And renewed
transactions do not suffer from the finalizer.

    benchmark                              old ns/op     new ns/op     delta
    BenchmarkEnv_ReaderList-4              72344         73023         +0.94%
    BenchmarkTxn_Put-4                     1754          1746          -0.46%
    BenchmarkTxn_PutReserve-4              1771          1733          -2.15%
    BenchmarkTxn_PutReserve_writemap-4     1519          1442          -5.07%
    BenchmarkTxn_Put_writemap-4            1446          1436          -0.69%
    BenchmarkTxn_Get_ro-4                  2469          2278          -7.74%
    BenchmarkTxn_Get_raw_ro-4              870           874           +0.46%
    BenchmarkScan_ro-4                     10521174      10206348      -2.99%
    BenchmarkScan_raw_ro-4                 1553810       1556701       +0.19%
    BenchmarkCursor-4                      553           544           -1.63%
    BenchmarkCursor_Renew-4                198           193           -2.53%
    BenchmarkTxn_Sub_commit-4              916848        565000        -38.38%
    BenchmarkTxn_Sub_abort-4               907221        553781        -38.96%
    BenchmarkTxn_abort-4                   17212         17430         +1.27%
    BenchmarkTxn_commit-4                  17233         17432         +1.15%
    BenchmarkTxn_ro-4                      136053        137380        +0.98%
    BenchmarkTxn_unmanaged_abort-4         17095         17883         +4.61%
    BenchmarkTxn_unmanaged_commit-4        17087         18069         +5.75%
    BenchmarkTxn_unmanaged_ro-4            732379        136897        -81.31%
    BenchmarkTxn_renew-4                   403           408           +1.24%
    BenchmarkTxn_Put_append-4              686           691           +0.73%
    BenchmarkTxn_Put_append_noflag-4       877           884           +0.80%