### PR TITLE
lmdb: add finalizer for readonly Cursors; fix obsure SIGABRT

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -96,8 +96,9 @@ func (c *Cursor) close() bool {
 	return false
 }
 
-// Close the cursor handle.  Cursors belonging to write transactions are closed
-// automatically when the transaction is terminated.
+// Close the cursor handle and clear the finalizer on c.  Cursors belonging to
+// write transactions are closed automatically when the transaction is
+// terminated.
 //
 // See mdb_cursor_close.
 func (c *Cursor) Close() {

--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -82,7 +82,7 @@ func (c *Cursor) Renew(txn *Txn) error {
 	return nil
 }
 
-func (c *Cursor) close() {
+func (c *Cursor) close() bool {
 	if c._c != nil {
 		if c.txn._txn == nil && !c.txn.readonly {
 			// the cursor has already been released by LMDB.
@@ -91,7 +91,9 @@ func (c *Cursor) close() {
 		}
 		c.txn = nil
 		c._c = nil
+		return true
 	}
+	return false
 }
 
 // Close the cursor handle.  Cursors belonging to write transactions are closed
@@ -99,8 +101,9 @@ func (c *Cursor) close() {
 //
 // See mdb_cursor_close.
 func (c *Cursor) Close() {
-	runtime.SetFinalizer(c, nil)
-	c.close()
+	if c.close() {
+		runtime.SetFinalizer(c, nil)
+	}
 }
 
 // Txn returns the cursor's transaction.

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -323,7 +323,7 @@ func (txn *Txn) Del(dbi DBI, key, val []byte) error {
 func (txn *Txn) OpenCursor(dbi DBI) (*Cursor, error) {
 	cur, err := openCursor(txn, dbi)
 	if cur != nil && txn.readonly {
-		runtime.SetFinalizer(cur, (*Cursor).Close)
+		runtime.SetFinalizer(cur, (*Cursor).close)
 	}
 	return cur, err
 }

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -79,9 +79,7 @@ func (txn *Txn) Commit() error {
 	if txn.managed {
 		panic("managed transaction cannot be comitted directly")
 	}
-	if txn != nil {
-		runtime.SetFinalizer(txn, nil)
-	}
+	runtime.SetFinalizer(txn, nil)
 	return txn.commit()
 }
 
@@ -99,9 +97,7 @@ func (txn *Txn) Abort() {
 	if txn.managed {
 		panic("managed transaction cannot be aborted directly")
 	}
-	if txn != nil {
-		runtime.SetFinalizer(txn, nil)
-	}
+	runtime.SetFinalizer(txn, nil)
 	txn.abort()
 }
 


### PR DESCRIPTION
Fixes #28

The Cursor.Close function is made idempotent as there is no way to tell
when a cursor is closed.  The Cursor.Close method will not call
mdb_cursor_close if the cursor's write transaction has closed because
resources have bene reclaimed.

A finalizer is used for only for readonly cursors because write
transactions will close their cursors on termination.

    benchmark                              old ns/op     new ns/op     delta
    BenchmarkEnv_ReaderList-4              78711         71540         -9.11%
    BenchmarkTxn_Put-4                     1732          1712          -1.15%
    BenchmarkTxn_PutReserve-4              1702          1727          +1.47%
    BenchmarkTxn_PutReserve_writemap-4     1465          1443          -1.50%
    BenchmarkTxn_Put_writemap-4            1446          1435          -0.76%
    BenchmarkTxn_Get_ro-4                  2476          2430          -1.86%
    BenchmarkTxn_Get_raw_ro-4              884           872           -1.36%
    BenchmarkScan_ro-4                     10274329      10270141      -0.04%
    BenchmarkScan_raw_ro-4                 1543669       1584085       +2.62%
    BenchmarkCursor-4                      554           2226          +301.81%
    BenchmarkCursor_Renew-4                195           196           +0.51%
    BenchmarkTxn_Sub_commit-4              556628        911970        +63.84%
    BenchmarkTxn_Sub_abort-4               563629        921204        +63.44%
    BenchmarkTxn_abort-4                   17678         17536         -0.80%
    BenchmarkTxn_commit-4                  17629         17425         -1.16%
    BenchmarkTxn_ro-4                      141248        795898        +463.48%
    BenchmarkTxn_unmanaged_abort-4         18575         19374         +4.30%
    BenchmarkTxn_unmanaged_commit-4        11331         19175         +69.23%
    BenchmarkTxn_unmanaged_ro-4            766156        788625        +2.93%
    BenchmarkTxn_renew-4                   413           408           -1.21%
    BenchmarkTxn_Put_append-4              697           675           -3.16%
    BenchmarkTxn_Put_append_noflag-4       895           878           -1.90%