### PR TITLE
lmdb: Cursor.DBI returns an "invalid" DBI if the cursor has been closed

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -112,11 +112,18 @@ func (c *Cursor) Txn() *Txn {
 	return c.txn
 }
 
-// DBI returns the cursor's database handle.
+// DBI returns the cursor's database handle.  If c has been closed than an
+// invalid DBI is returned.
 func (c *Cursor) DBI() DBI {
+	// dbiInvalid is an invalid DBI (the max value for the type).  it shouldn't
+	// be possible to create a database handle with value dbiInvalid because
+	// the process address space would be exhausted.  it is also impractical to
+	// have many open databases in an environment.
+	const dbiInvalid = ^DBI(0)
+
 	// mdb_cursor_dbi segfaults when passed a nil value
 	if c._c == nil {
-		return 0
+		return dbiInvalid
 	}
 	return DBI(C.mdb_cursor_dbi(c._c))
 }

--- a/lmdb/cursor_test.go
+++ b/lmdb/cursor_test.go
@@ -67,7 +67,7 @@ func TestCursor_DBI(t *testing.T) {
 		if dbcur == db {
 			return fmt.Errorf("db: %v", dbcur)
 		}
-		if dbcur != 0 {
+		if dbcur != ^DBI(0) {
 			return fmt.Errorf("db: %v", dbcur)
 		}
 		return nil


### PR DESCRIPTION
Fixes #31

The returned DBI is the maximum value for the DBI type.  It shouldn't be
possible to actually have that many open databases because the address
space would be exhausted.  So any attempt to use the returned value will
result in an error.