### PR TITLE
Fix spurious compiler warning on OS X

### DIFF
--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -54,7 +54,7 @@ applications.
 package lmdb
 
 /*
-#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wbad-function-cast -O2 -g
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -O2 -g
 #cgo freebsd CFLAGS: -DMDB_DSYNC=O_SYNC
 #cgo openbsd CFLAGS: -DMDB_DSYNC=O_SYNC
 #cgo netbsd CFLAGS: -DMDB_DSYNC=O_SYNC


### PR DESCRIPTION
Clang on OS X warns when making test:
```
lmdb/mdb.c:9466:46: warning: data argument not used by format string [-Wformat-extra-args]
```

The code in question uses a ternary statement to decide which format string to use, which Clang is not
smart enough to figure out.

You can argue this should be two sprintf() calls, but I'd rather not modify the LMDB source.