### PR TITLE
lmdb: clean up C.MDB_val internals

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -136,7 +136,7 @@ func (c *Cursor) DBI() DBI {
 //
 // See mdb_cursor_get.
 func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error) {
-	var k, v *mdbVal
+	var k, v *C.MDB_val
 	switch {
 	case len(setkey) == 0:
 		k, v, err = c.getVal0(op)
@@ -155,9 +155,9 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 // data for reference (Next, First, Last, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal0(op uint) (key, val *mdbVal, err error) {
-	key = new(mdbVal)
-	val = new(mdbVal)
+func (c *Cursor) getVal0(op uint) (key, val *C.MDB_val, err error) {
+	key = new(C.MDB_val)
+	val = new(C.MDB_val)
 	ret := C.mdb_cursor_get(c._c, (*C.MDB_val)(key), (*C.MDB_val)(val), C.MDB_cursor_op(op))
 	return key, val, operrno("mdb_cursor_get", ret)
 }
@@ -166,9 +166,9 @@ func (c *Cursor) getVal0(op uint) (key, val *mdbVal, err error) {
 // (Set, SetRange, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal1(setkey []byte, op uint) (key, val *mdbVal, err error) {
-	key = new(mdbVal)
-	val = new(mdbVal)
+func (c *Cursor) getVal1(setkey []byte, op uint) (key, val *C.MDB_val, err error) {
+	key = new(C.MDB_val)
+	val = new(C.MDB_val)
 	kdata, kn := valBytes(setkey)
 	ret := C.lmdbgo_mdb_cursor_get1(
 		c._c,
@@ -183,9 +183,9 @@ func (c *Cursor) getVal1(setkey []byte, op uint) (key, val *mdbVal, err error) {
 // reference (GetBoth, GetBothRange, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal2(setkey, setval []byte, op uint) (key, val *mdbVal, err error) {
-	key = new(mdbVal)
-	val = new(mdbVal)
+func (c *Cursor) getVal2(setkey, setval []byte, op uint) (key, val *C.MDB_val, err error) {
+	key = new(C.MDB_val)
+	val = new(C.MDB_val)
 	kdata, kn := valBytes(setkey)
 	vdata, vn := valBytes(setval)
 	ret := C.lmdbgo_mdb_cursor_get2(
@@ -218,18 +218,18 @@ func (c *Cursor) Put(key, val []byte, flags uint) error {
 // before it has terminated.
 func (c *Cursor) PutReserve(key []byte, n int, flags uint) ([]byte, error) {
 	kdata, kn := valBytes(key)
-	cval := &mdbVal{mv_size: C.size_t(n)}
+	val := &C.MDB_val{mv_size: C.size_t(n)}
 	ret := C.lmdbgo_mdb_cursor_put1(
 		c._c,
 		kdata, C.size_t(kn),
-		(*C.MDB_val)(cval),
+		(*C.MDB_val)(val),
 		C.uint(flags|C.MDB_RESERVE),
 	)
 	err := operrno("mdb_cursor_put", ret)
 	if err != nil {
 		return nil, err
 	}
-	return cval.Bytes(), nil
+	return getBytes(val), nil
 }
 
 // PutMulti stores a set of contiguous items with stride size under key.

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -261,11 +261,11 @@ func (txn *Txn) subFlag(flags uint, fn TxnOp) error {
 	return sub.commit()
 }
 
-func (txn *Txn) bytes(val *mdbVal) []byte {
+func (txn *Txn) bytes(val *C.MDB_val) []byte {
 	if txn.RawRead {
-		return val.Bytes()
+		return getBytes(val)
 	}
-	return val.BytesCopy()
+	return getBytesCopy(val)
 }
 
 // Get retrieves items from database dbi.  If txn.RawRead is true the slice
@@ -275,7 +275,7 @@ func (txn *Txn) bytes(val *mdbVal) []byte {
 // See mdb_get.
 func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	kdata, kn := valBytes(key)
-	val := new(mdbVal)
+	val := new(C.MDB_val)
 	ret := C.lmdbgo_mdb_get(
 		txn._txn, C.MDB_dbi(dbi),
 		kdata, C.size_t(kn),
@@ -308,7 +308,7 @@ func (txn *Txn) Put(dbi DBI, key []byte, val []byte, flags uint) error {
 // before it has terminated.
 func (txn *Txn) PutReserve(dbi DBI, key []byte, n int, flags uint) ([]byte, error) {
 	kdata, kn := valBytes(key)
-	val := &mdbVal{mv_size: C.size_t(n)}
+	val := &C.MDB_val{mv_size: C.size_t(n)}
 	ret := C.lmdbgo_mdb_put1(
 		txn._txn, C.MDB_dbi(dbi),
 		kdata, C.size_t(kn),
@@ -319,7 +319,7 @@ func (txn *Txn) PutReserve(dbi DBI, key []byte, n int, flags uint) ([]byte, erro
 	if err != nil {
 		return nil, err
 	}
-	return val.Bytes(), nil
+	return getBytes(val), nil
 }
 
 // Del deletes an item from database dbi.  Del ignores val unless dbi has the

--- a/lmdb/val_test.go
+++ b/lmdb/val_test.go
@@ -64,31 +64,22 @@ func TestValBytes(t *testing.T) {
 }
 
 func TestVal(t *testing.T) {
-	orig := "hey hey"
-	val := wrapVal([]byte(orig))
+	orig := []byte("hey hey")
+	val := wrapVal(orig)
 
-	s := val.String()
-	if s != orig {
-		t.Errorf("String() not the same as original data: %q", s)
+	p := getBytes(val)
+	if !bytes.Equal(p, orig) {
+		t.Errorf("getBytes() not the same as original data: %q", p)
+	}
+	if &p[0] != &orig[0] {
+		t.Errorf("getBytes() is not the same slice as original")
 	}
 
-	p := val.Bytes()
-	if string(p) != orig {
-		t.Errorf("Bytes() not the same as original data: %q", p)
+	p = getBytesCopy(val)
+	if !bytes.Equal(p, orig) {
+		t.Errorf("getBytesCopy() not the same as original data: %q", p)
 	}
-}
-
-func TestValCopy(t *testing.T) {
-	orig := "hey hey"
-	val := wrapVal([]byte(orig))
-
-	s := val.String()
-	if s != orig {
-		t.Errorf("String() not the same as original data: %q", s)
-	}
-
-	p := val.BytesCopy()
-	if string(p) != orig {
-		t.Errorf("Bytes() not the same as original data: %q", p)
+	if &p[0] == &orig[0] {
+		t.Errorf("getBytesCopy() overlaps with orignal slice")
 	}
 }


### PR DESCRIPTION
The mdbVal type was vestigial after updating for the cgo changes in go1.6. I extracted the meaningful functions and removed the type definition.