### PR TITLE
Fix cgo argument check panic for small slices from bytes.Buffer (and similar types)

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -210,22 +210,16 @@ func (c *Cursor) Put(key, val []byte, flags uint) error {
 	if len(key) == 0 {
 		return c.putNilKey(flags)
 	}
-	var ret C.int
-	if len(val) != 0 {
-		ret = C.lmdbgo_mdb_cursor_put2(
-			c._c,
-			unsafe.Pointer(&key[0]), C.size_t(len(key)),
-			unsafe.Pointer(&val[0]), C.size_t(len(val)),
-			C.uint(flags),
-		)
-	} else {
-		ret = C.lmdbgo_mdb_cursor_put2(
-			c._c,
-			unsafe.Pointer(&key[0]), C.size_t(len(key)),
-			nil, 0,
-			C.uint(flags),
-		)
+	vn := len(val)
+	if vn == 0 {
+		val = []byte{0}
 	}
+	ret := C.lmdbgo_mdb_cursor_put2(
+		c._c,
+		unsafe.Pointer(&key[0]), C.size_t(len(key)),
+		unsafe.Pointer(&val[0]), C.size_t(len(val)),
+		C.uint(flags),
+	)
 	return operrno("mdb_cursor_put", ret)
 }
 
@@ -261,13 +255,7 @@ func (c *Cursor) PutMulti(key []byte, page []byte, stride int, flags uint) error
 		return c.putNilKey(flags)
 	}
 	if len(page) == 0 {
-		ret := C.lmdbgo_mdb_cursor_putmulti(
-			c._c,
-			unsafe.Pointer(&key[0]), C.size_t(len(key)),
-			nil, 0, C.size_t(stride),
-			C.uint(flags|C.MDB_MULTIPLE),
-		)
-		return operrno("mdb_cursor_put", ret)
+		page = []byte{0}
 	}
 
 	vn := WrapMulti(page, stride).Len()

--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -7,7 +7,10 @@ package lmdb
 #include "lmdbgo.h"
 */
 import "C"
-import "runtime"
+import (
+	"runtime"
+	"unsafe"
+)
 
 // These flags are used exclusively for Cursor.Get.
 const (
@@ -172,7 +175,7 @@ func (c *Cursor) getVal1(setkey []byte, op uint) (key, val *C.MDB_val, err error
 	kdata, kn := valBytes(setkey)
 	ret := C.lmdbgo_mdb_cursor_get1(
 		c._c,
-		kdata, C.size_t(kn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
 		(*C.MDB_val)(key), (*C.MDB_val)(val),
 		C.MDB_cursor_op(op),
 	)
@@ -190,8 +193,8 @@ func (c *Cursor) getVal2(setkey, setval []byte, op uint) (key, val *C.MDB_val, e
 	vdata, vn := valBytes(setval)
 	ret := C.lmdbgo_mdb_cursor_get2(
 		c._c,
-		kdata, C.size_t(kn),
-		vdata, C.size_t(vn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		unsafe.Pointer(&vdata[0]), C.size_t(vn),
 		(*C.MDB_val)(key), (*C.MDB_val)(val),
 		C.MDB_cursor_op(op),
 	)
@@ -206,8 +209,8 @@ func (c *Cursor) Put(key, val []byte, flags uint) error {
 	vdata, vn := valBytes(val)
 	ret := C.lmdbgo_mdb_cursor_put2(
 		c._c,
-		kdata, C.size_t(kn),
-		vdata, C.size_t(vn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		unsafe.Pointer(&vdata[0]), C.size_t(vn),
 		C.uint(flags),
 	)
 	return operrno("mdb_cursor_put", ret)
@@ -221,7 +224,7 @@ func (c *Cursor) PutReserve(key []byte, n int, flags uint) ([]byte, error) {
 	val := &C.MDB_val{mv_size: C.size_t(n)}
 	ret := C.lmdbgo_mdb_cursor_put1(
 		c._c,
-		kdata, C.size_t(kn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
 		(*C.MDB_val)(val),
 		C.uint(flags|C.MDB_RESERVE),
 	)
@@ -243,8 +246,8 @@ func (c *Cursor) PutMulti(key []byte, page []byte, stride int, flags uint) error
 	vn := WrapMulti(page, stride).Len()
 	ret := C.lmdbgo_mdb_cursor_putmulti(
 		c._c,
-		kdata, C.size_t(kn),
-		vdata, C.size_t(vn), C.size_t(stride),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		unsafe.Pointer(&vdata[0]), C.size_t(vn), C.size_t(stride),
 		C.uint(flags|C.MDB_MULTIPLE),
 	)
 	return operrno("mdb_cursor_put", ret)

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -278,7 +278,7 @@ func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	val := new(C.MDB_val)
 	ret := C.lmdbgo_mdb_get(
 		txn._txn, C.MDB_dbi(dbi),
-		kdata, C.size_t(kn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
 		(*C.MDB_val)(val),
 	)
 	err := operrno("mdb_get", ret)
@@ -296,8 +296,8 @@ func (txn *Txn) Put(dbi DBI, key []byte, val []byte, flags uint) error {
 	vdata, vn := valBytes(val)
 	ret := C.lmdbgo_mdb_put2(
 		txn._txn, C.MDB_dbi(dbi),
-		kdata, C.size_t(kn),
-		vdata, C.size_t(vn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		unsafe.Pointer(&vdata[0]), C.size_t(vn),
 		C.uint(flags),
 	)
 	return operrno("mdb_put", ret)
@@ -311,7 +311,7 @@ func (txn *Txn) PutReserve(dbi DBI, key []byte, n int, flags uint) ([]byte, erro
 	val := &C.MDB_val{mv_size: C.size_t(n)}
 	ret := C.lmdbgo_mdb_put1(
 		txn._txn, C.MDB_dbi(dbi),
-		kdata, C.size_t(kn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
 		(*C.MDB_val)(val),
 		C.uint(flags|C.MDB_RESERVE),
 	)
@@ -331,8 +331,8 @@ func (txn *Txn) Del(dbi DBI, key, val []byte) error {
 	vdata, vn := valBytes(val)
 	ret := C.lmdbgo_mdb_del(
 		txn._txn, C.MDB_dbi(dbi),
-		kdata, C.size_t(kn),
-		vdata, C.size_t(vn),
+		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		unsafe.Pointer(&vdata[0]), C.size_t(vn),
 	)
 	return operrno("mdb_del", ret)
 }

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -298,26 +298,21 @@ func (txn *Txn) putNilKey(dbi DBI, flags uint) error {
 //
 // See mdb_put.
 func (txn *Txn) Put(dbi DBI, key []byte, val []byte, flags uint) error {
-	if len(key) == 0 {
+	kn := len(key)
+	if kn == 0 {
 		return txn.putNilKey(dbi, flags)
 	}
-
-	var ret C.int
-	if len(val) != 0 {
-		ret = C.lmdbgo_mdb_put2(
-			txn._txn, C.MDB_dbi(dbi),
-			unsafe.Pointer(&key[0]), C.size_t(len(key)),
-			unsafe.Pointer(&val[0]), C.size_t(len(val)),
-			C.uint(flags),
-		)
-	} else {
-		ret = C.lmdbgo_mdb_put2(
-			txn._txn, C.MDB_dbi(dbi),
-			unsafe.Pointer(&key[0]), C.size_t(len(key)),
-			nil, 0,
-			C.uint(flags),
-		)
+	vn := len(val)
+	if vn == 0 {
+		val = []byte{0}
 	}
+
+	ret := C.lmdbgo_mdb_put2(
+		txn._txn, C.MDB_dbi(dbi),
+		unsafe.Pointer(&key[0]), C.size_t(kn),
+		unsafe.Pointer(&val[0]), C.size_t(vn),
+		C.uint(flags),
+	)
 	return operrno("mdb_put", ret)
 }
 

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -253,6 +253,46 @@ func TestTxn_PutReserve(t *testing.T) {
 	}
 }
 
+func TestTxn_bytesBuffer(t *testing.T) {
+	env := setup(t)
+	defer clean(env, t)
+
+	db, err := openRoot(env, 0)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = env.Update(func(txn *Txn) (err error) {
+		k := new(bytes.Buffer)
+		k.WriteString("hello")
+		v := new(bytes.Buffer)
+		v.WriteString("world")
+		return txn.Put(db, k.Bytes(), v.Bytes(), 0)
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	err = env.View(func(txn *Txn) (err error) {
+		k := new(bytes.Buffer)
+		k.WriteString("hello")
+		v, err := txn.Get(db, k.Bytes())
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(v, []byte("world")) {
+			return fmt.Errorf("unexpected value: %q", v)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func TestTxn_Put_overwrite(t *testing.T) {
 	env := setup(t)
 	defer clean(env, t)

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -214,6 +214,35 @@ func TestTxn_Del_dup(t *testing.T) {
 	}
 }
 
+func TestTexn_Put_emptyValue(t *testing.T) {
+	env := setup(t)
+	defer clean(env, t)
+
+	var db DBI
+	err := env.Update(func(txn *Txn) (err error) {
+		db, err = txn.OpenRoot(0)
+		if err != nil {
+			return err
+		}
+		err = txn.Put(db, []byte("k"), nil, 0)
+		if err != nil {
+			return err
+		}
+		v, err := txn.Get(db, []byte("k"))
+		if err != nil {
+			return err
+		}
+		if len(v) != 0 {
+			t.Errorf("value: %q (!= \"\")", v)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+}
+
 func TestTxn_PutReserve(t *testing.T) {
 	env := setup(t)
 	defer clean(env, t)

--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -78,17 +78,19 @@ func (m *Multi) Page() []byte {
 	return m.page[:len(m.page):len(m.page)]
 }
 
-func valBytes(b []byte) (unsafe.Pointer, int) {
+var eb = []byte{0}
+
+func valBytes(b []byte) ([]byte, int) {
 	if len(b) == 0 {
-		return nil, 0
+		return eb, 0
 	}
-	return unsafe.Pointer(&b[0]), len(b)
+	return b, len(b)
 }
 
 func wrapVal(b []byte) *C.MDB_val {
-	ptr, n := valBytes(b)
+	p, n := valBytes(b)
 	return &C.MDB_val{
-		mv_data: unsafe.Pointer(ptr),
+		mv_data: unsafe.Pointer(&p[0]),
 		mv_size: C.size_t(n),
 	}
 }

--- a/lmdb/val_test.go
+++ b/lmdb/val_test.go
@@ -46,8 +46,8 @@ func TestMultiVal_panic(t *testing.T) {
 
 func TestValBytes(t *testing.T) {
 	ptr, n := valBytes(nil)
-	if ptr != nil {
-		t.Errorf("unexpected non-nil pointer")
+	if len(ptr) == 0 {
+		t.Errorf("unexpected unadressable slice")
 	}
 	if n != 0 {
 		t.Errorf("unexpected length: %d (expected 0)", n)
@@ -55,8 +55,8 @@ func TestValBytes(t *testing.T) {
 
 	b := []byte("abc")
 	ptr, n = valBytes(b)
-	if ptr == nil {
-		t.Errorf("unexpected nil pointer")
+	if len(ptr) == 0 {
+		t.Errorf("unexpected unadressable slice")
 	}
 	if n != 3 {
 		t.Errorf("unexpected length: %d (expected %d)", n, len(b))

--- a/lmdb/val_test.go
+++ b/lmdb/val_test.go
@@ -47,7 +47,7 @@ func TestMultiVal_panic(t *testing.T) {
 func TestValBytes(t *testing.T) {
 	ptr, n := valBytes(nil)
 	if len(ptr) == 0 {
-		t.Errorf("unexpected unadressable slice")
+		t.Errorf("unexpected unaddressable slice")
 	}
 	if n != 0 {
 		t.Errorf("unexpected length: %d (expected 0)", n)
@@ -56,7 +56,7 @@ func TestValBytes(t *testing.T) {
 	b := []byte("abc")
 	ptr, n = valBytes(b)
 	if len(ptr) == 0 {
-		t.Errorf("unexpected unadressable slice")
+		t.Errorf("unexpected unaddressable slice")
 	}
 	if n != 3 {
 		t.Errorf("unexpected length: %d (expected %d)", n, len(b))


### PR DESCRIPTION
Fixes #56 

The `valBytes()` function has been modified to return a non-empty slice of bytes for any (possibly empty) input slice. The length returned is always the true length of the input.

This is a hack that allows the cgo tool to correctly identify the argument type as the slice and not the bytes.Buffer (or whatever containing type causes these types of panics).