### PR TITLE
lmdb: Enable MDB_USE_PWRITEV on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,13 @@ Building commands and running tests can be done with `go` or with `make`
     make check
     make all
 
+On Linux, you can specify the `pwritev` build tag to reduce the number of syscalls
+required when committing a transaction. In your own package you can then do
+
+    go build -tags pwritev .
+
+to enable the optimisation.
+
 ##Documentation
 
 ###Go doc

--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -55,6 +55,7 @@ package lmdb
 
 /*
 #cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -O2 -g
+#cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
 
 #include "lmdb.h"
 */


### PR DESCRIPTION
This is a small optimization, which turns a seek + writev into a pwritev syscall on Linux.