### PR TITLE
recently golint was made to only compile for go version >=1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-- 1.4
 - 1.5
 - 1.6
 - tip


### PR DESCRIPTION
The dependency on the go/types package breaks compilation on earlier
versions.