### PR TITLE
lmdb: internal C.MDB_val fields in Txn for re-use during Get/PutReserve

### DIFF
--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -49,6 +49,8 @@ type Txn struct {
 	env      *Env
 	_txn     *C.MDB_txn
 	errLogf  func(format string, v ...interface{})
+	key      *C.MDB_val
+	val      *C.MDB_val
 }
 
 // beginTxn does not lock the OS thread which is a prerequisite for creating a
@@ -58,11 +60,16 @@ func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
 		readonly: (flags&Readonly != 0),
 		env:      env,
 	}
+
 	var ptxn *C.MDB_txn
 	if parent == nil {
 		ptxn = nil
+		txn.key = new(C.MDB_val)
+		txn.val = new(C.MDB_val)
 	} else {
 		ptxn = parent._txn
+		txn.key = parent.key
+		txn.val = parent.val
 	}
 	ret := C.mdb_txn_begin(env._env, ptxn, C.uint(flags), &txn._txn)
 	if ret != success {
@@ -275,17 +282,19 @@ func (txn *Txn) bytes(val *C.MDB_val) []byte {
 // See mdb_get.
 func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	kdata, kn := valBytes(key)
-	val := new(C.MDB_val)
 	ret := C.lmdbgo_mdb_get(
 		txn._txn, C.MDB_dbi(dbi),
 		unsafe.Pointer(&kdata[0]), C.size_t(kn),
-		(*C.MDB_val)(val),
+		txn.val,
 	)
 	err := operrno("mdb_get", ret)
 	if err != nil {
+		*txn.val = C.MDB_val{}
 		return nil, err
 	}
-	return txn.bytes(val), nil
+	b := txn.bytes(txn.val)
+	*txn.val = C.MDB_val{}
+	return b, nil
 }
 
 func (txn *Txn) putNilKey(dbi DBI, flags uint) error {
@@ -323,18 +332,21 @@ func (txn *Txn) PutReserve(dbi DBI, key []byte, n int, flags uint) ([]byte, erro
 	if len(key) == 0 {
 		return nil, txn.putNilKey(dbi, flags)
 	}
-	val := &C.MDB_val{mv_size: C.size_t(n)}
+	txn.val.mv_size = C.size_t(n)
 	ret := C.lmdbgo_mdb_put1(
 		txn._txn, C.MDB_dbi(dbi),
 		unsafe.Pointer(&key[0]), C.size_t(len(key)),
-		(*C.MDB_val)(val),
+		txn.val,
 		C.uint(flags|C.MDB_RESERVE),
 	)
 	err := operrno("mdb_put", ret)
 	if err != nil {
+		*txn.val = C.MDB_val{}
 		return nil, err
 	}
-	return getBytes(val), nil
+	b := getBytes(txn.val)
+	*txn.val = C.MDB_val{}
+	return b, nil
 }
 
 // Del deletes an item from database dbi.  Del ignores val unless dbi has the


### PR DESCRIPTION
Closes #59