### PR TITLE
lmdb: Return dedicated ErrNotFound from Txn.Get and Cursor.Get

### DIFF
--- a/lmdb/bench_test.go
+++ b/lmdb/bench_test.go
@@ -271,6 +271,33 @@ func BenchmarkTxn_Get_raw_ro(b *testing.B) {
 	}
 }
 
+// Get a missing key, with RawRead turned on.
+func BenchmarkTxn_Get_missing_raw(b *testing.B) {
+	env := setup(b)
+	defer clean(env, b)
+
+	dbi := openBenchDBI(b, env)
+
+	err := env.View(func(txn *Txn) (err error) {
+		txn.RawRead = true
+		key := []byte("does not exist")
+
+		b.ResetTimer()
+		defer b.StopTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := txn.Get(dbi, key)
+			if !IsNotFound(err) {
+				b.Fatalf("found non-existent key: %v", err)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Error(err)
+		return
+	}
+}
+
 // repeatedly scan all the values in a database.
 func BenchmarkScan_ro(b *testing.B) {
 	initRandSource(b)

--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -137,16 +137,27 @@ func (c *Cursor) DBI() DBI {
 //
 // Get ignores setval if setkey is empty.
 //
+// Returns ErrNotFound if setkey is not present.
+//
 // See mdb_cursor_get.
 func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error) {
+	var ret C.int
 	switch {
 	case len(setkey) == 0:
-		err = c.getVal0(op)
+		ret = c.getVal0(op)
 	case len(setval) == 0:
-		err = c.getVal1(setkey, op)
+		ret = c.getVal1(setkey, op)
 	default:
-		err = c.getVal2(setkey, setval, op)
+		ret = c.getVal2(setkey, setval, op)
 	}
+
+	if ret == C.MDB_NOTFOUND {
+		*c.txn.key = C.MDB_val{}
+		*c.txn.val = C.MDB_val{}
+		return nil, nil, ErrNotFound
+	}
+
+	err = operrno("mdb_cursor_get", ret)
 	if err != nil {
 		*c.txn.key = C.MDB_val{}
 		*c.txn.val = C.MDB_val{}
@@ -163,38 +174,35 @@ func (c *Cursor) Get(setkey, setval []byte, op uint) (key, val []byte, err error
 // data for reference (Next, First, Last, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal0(op uint) error {
-	ret := C.mdb_cursor_get(c._c, c.txn.key, c.txn.val, C.MDB_cursor_op(op))
-	return operrno("mdb_cursor_get", ret)
+func (c *Cursor) getVal0(op uint) C.int {
+	return C.mdb_cursor_get(c._c, c.txn.key, c.txn.val, C.MDB_cursor_op(op))
 }
 
 // getVal1 retrieves items from the database using key data for reference
 // (Set, SetRange, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal1(setkey []byte, op uint) error {
-	ret := C.lmdbgo_mdb_cursor_get1(
+func (c *Cursor) getVal1(setkey []byte, op uint) C.int {
+	return C.lmdbgo_mdb_cursor_get1(
 		c._c,
 		unsafe.Pointer(&setkey[0]), C.size_t(len(setkey)),
 		c.txn.key, c.txn.val,
 		C.MDB_cursor_op(op),
 	)
-	return operrno("mdb_cursor_get", ret)
 }
 
 // getVal2 retrieves items from the database using key and value data for
 // reference (GetBoth, GetBothRange, etc).
 //
 // See mdb_cursor_get.
-func (c *Cursor) getVal2(setkey, setval []byte, op uint) error {
-	ret := C.lmdbgo_mdb_cursor_get2(
+func (c *Cursor) getVal2(setkey, setval []byte, op uint) C.int {
+	return C.lmdbgo_mdb_cursor_get2(
 		c._c,
 		unsafe.Pointer(&setkey[0]), C.size_t(len(setkey)),
 		unsafe.Pointer(&setval[0]), C.size_t(len(setval)),
 		c.txn.key, c.txn.val,
 		C.MDB_cursor_op(op),
 	)
-	return operrno("mdb_cursor_get", ret)
 }
 
 func (c *Cursor) putNilKey(flags uint) error {

--- a/lmdb/error.go
+++ b/lmdb/error.go
@@ -70,6 +70,9 @@ const (
 //		lmdb.IsErrnoFn(err, os.IsPermission)
 type Errno C.int
 
+// ErrNotFound is returned by Txn.Get and Cursor.Get
+var ErrNotFound = &OpError{"lmdb", NotFound}
+
 // minimum and maximum values produced for the Errno type. syscall.Errnos of
 // other values may still be produced.
 const minErrno, maxErrno C.int = C.MDB_KEYEXIST, C.MDB_LAST_ERRCODE
@@ -87,7 +90,7 @@ func _operrno(op string, ret int) error {
 // not exist or if the Cursor reached the end of the database without locating
 // a value (EOF).
 func IsNotFound(err error) bool {
-	return IsErrno(err, NotFound)
+	return err == ErrNotFound
 }
 
 // IsNotExist returns true the path passed to the Env.Open method does not
@@ -123,6 +126,9 @@ func IsErrnoSys(err error, errno syscall.Errno) bool {
 func IsErrnoFn(err error, fn func(error) bool) bool {
 	if err == nil {
 		return false
+	}
+	if err == ErrNotFound {
+		return fn(NotFound)
 	}
 	if err, ok := err.(*OpError); ok {
 		return fn(err.Errno)


### PR DESCRIPTION
This avoids allocation of a new Error every time we look up a key that does not exist, saving two allocations per lookup.

I have a use case where most lookups end up not existing in the database, where this comes in handy. I considered changing operrno at first, unfortunately mdb_dbi_open returns MDB_NOTFOUND as well. Returning ErrNotFound in that case would have been too confusing I think.

Not sure I got all the documentation changes right, lmk what needs fixing.