### PR TITLE
Switch void* C arguments to char* to avoid allocations and linear data check

### DIFF
--- a/lmdb/cursor.go
+++ b/lmdb/cursor.go
@@ -175,7 +175,7 @@ func (c *Cursor) getVal0(op uint) error {
 func (c *Cursor) getVal1(setkey []byte, op uint) error {
 	ret := C.lmdbgo_mdb_cursor_get1(
 		c._c,
-		unsafe.Pointer(&setkey[0]), C.size_t(len(setkey)),
+		(*C.char)(unsafe.Pointer(&setkey[0])), C.size_t(len(setkey)),
 		c.txn.key, c.txn.val,
 		C.MDB_cursor_op(op),
 	)
@@ -189,8 +189,8 @@ func (c *Cursor) getVal1(setkey []byte, op uint) error {
 func (c *Cursor) getVal2(setkey, setval []byte, op uint) error {
 	ret := C.lmdbgo_mdb_cursor_get2(
 		c._c,
-		unsafe.Pointer(&setkey[0]), C.size_t(len(setkey)),
-		unsafe.Pointer(&setval[0]), C.size_t(len(setval)),
+		(*C.char)(unsafe.Pointer(&setkey[0])), C.size_t(len(setkey)),
+		(*C.char)(unsafe.Pointer(&setval[0])), C.size_t(len(setval)),
 		c.txn.key, c.txn.val,
 		C.MDB_cursor_op(op),
 	)
@@ -215,8 +215,8 @@ func (c *Cursor) Put(key, val []byte, flags uint) error {
 	}
 	ret := C.lmdbgo_mdb_cursor_put2(
 		c._c,
-		unsafe.Pointer(&key[0]), C.size_t(len(key)),
-		unsafe.Pointer(&val[0]), C.size_t(len(val)),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(len(key)),
+		(*C.char)(unsafe.Pointer(&val[0])), C.size_t(len(val)),
 		C.uint(flags),
 	)
 	return operrno("mdb_cursor_put", ret)
@@ -233,7 +233,7 @@ func (c *Cursor) PutReserve(key []byte, n int, flags uint) ([]byte, error) {
 	c.txn.val.mv_size = C.size_t(n)
 	ret := C.lmdbgo_mdb_cursor_put1(
 		c._c,
-		unsafe.Pointer(&key[0]), C.size_t(len(key)),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(len(key)),
 		c.txn.val,
 		C.uint(flags|C.MDB_RESERVE),
 	)
@@ -263,8 +263,8 @@ func (c *Cursor) PutMulti(key []byte, page []byte, stride int, flags uint) error
 	vn := WrapMulti(page, stride).Len()
 	ret := C.lmdbgo_mdb_cursor_putmulti(
 		c._c,
-		unsafe.Pointer(&key[0]), C.size_t(len(key)),
-		unsafe.Pointer(&page[0]), C.size_t(vn), C.size_t(stride),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(len(key)),
+		(*C.char)(unsafe.Pointer(&page[0])), C.size_t(vn), C.size_t(stride),
 		C.uint(flags|C.MDB_MULTIPLE),
 	)
 	return operrno("mdb_cursor_put", ret)

--- a/lmdb/lmdbgo.c
+++ b/lmdb/lmdbgo.c
@@ -23,46 +23,46 @@ int lmdbgo_mdb_reader_list(MDB_env *env, size_t ctx) {
 	return mdb_reader_list(env, 0, (void *)ctx);
 }
 
-int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, void *vdata, size_t vn) {
+int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn) {
     MDB_val key, val;
     LMDBGO_SET_VAL(&key, kn, kdata);
     LMDBGO_SET_VAL(&val, vn, vdata);
     return mdb_del(txn, dbi, &key, &val);
 }
 
-int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, MDB_val *val) {
+int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val) {
     MDB_val key;
     LMDBGO_SET_VAL(&key, kn, kdata);
     return mdb_get(txn, dbi, &key, val);
 }
 
-int lmdbgo_mdb_put2(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, void *vdata, size_t vn, unsigned int flags) {
+int lmdbgo_mdb_put2(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn, unsigned int flags) {
     MDB_val key, val;
     LMDBGO_SET_VAL(&key, kn, kdata);
     LMDBGO_SET_VAL(&val, vn, vdata);
     return mdb_put(txn, dbi, &key, &val, flags);
 }
 
-int lmdbgo_mdb_put1(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, MDB_val *val, unsigned int flags) {
+int lmdbgo_mdb_put1(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val, unsigned int flags) {
     MDB_val key;
     LMDBGO_SET_VAL(&key, kn, kdata);
     return mdb_put(txn, dbi, &key, val, flags);
 }
 
-int lmdbgo_mdb_cursor_put2(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, unsigned int flags) {
+int lmdbgo_mdb_cursor_put2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, unsigned int flags) {
     MDB_val key, val;
     LMDBGO_SET_VAL(&key, kn, kdata);
     LMDBGO_SET_VAL(&val, vn, vdata);
     return mdb_cursor_put(cur, &key, &val, flags);
 }
 
-int lmdbgo_mdb_cursor_put1(MDB_cursor *cur, void *kdata, size_t kn, MDB_val *val, unsigned int flags) {
+int lmdbgo_mdb_cursor_put1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *val, unsigned int flags) {
     MDB_val key;
     LMDBGO_SET_VAL(&key, kn, kdata);
     return mdb_cursor_put(cur, &key, val, flags);
 }
 
-int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, size_t vstride, unsigned int flags) {
+int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, size_t vstride, unsigned int flags) {
     MDB_val key, val[2];
     LMDBGO_SET_VAL(&key, kn, kdata);
     LMDBGO_SET_VAL(&(val[0]), vstride, vdata);
@@ -70,12 +70,12 @@ int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, void *kdata, size_t kn, void *vd
     return mdb_cursor_put(cur, &key, &val[0], flags);
 }
 
-int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, void *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
+int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
     LMDBGO_SET_VAL(key, kn, kdata);
     return mdb_cursor_get(cur, key, val, op);
 }
 
-int lmdbgo_mdb_cursor_get2(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
+int lmdbgo_mdb_cursor_get2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDB_val *key, MDB_val *val, MDB_cursor_op op) {
     LMDBGO_SET_VAL(key, kn, kdata);
     LMDBGO_SET_VAL(val, vn, vdata);
     return mdb_cursor_get(cur, key, val, op);

--- a/lmdb/lmdbgo.h
+++ b/lmdb/lmdbgo.h
@@ -7,6 +7,16 @@
 
 #include "lmdb.h"
 
+/* Proxy functions for lmdb get/put operations. The functions are defined to
+ * take char* values instead of void* to keep cgo from cheking their data for
+ * nested pointers and causing a couple of allocations per argument.
+ *
+ * For more information see github issues for more information about the
+ * problem and the decision.
+ *      https://github.com/golang/go/issues/14387
+ *      https://github.com/golang/go/issues/15048
+ *      https://github.com/bmatsuo/lmdb-go/issues/63
+ * */
 int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn);
 int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val);
 int lmdbgo_mdb_put1(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val, unsigned int flags);

--- a/lmdb/lmdbgo.h
+++ b/lmdb/lmdbgo.h
@@ -7,15 +7,15 @@
 
 #include "lmdb.h"
 
-int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, void *vdata, size_t vn);
-int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, MDB_val *val);
-int lmdbgo_mdb_put1(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, MDB_val *val, unsigned int flags);
-int lmdbgo_mdb_put2(MDB_txn *txn, MDB_dbi dbi, void *kdata, size_t kn, void *vdata, size_t vn, unsigned int flags);
-int lmdbgo_mdb_cursor_put1(MDB_cursor *cur, void *kdata, size_t kn, MDB_val *val, unsigned int flags);
-int lmdbgo_mdb_cursor_put2(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, unsigned int flags);
-int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, size_t vstride, unsigned int flags);
-int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, void *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
-int lmdbgo_mdb_cursor_get2(MDB_cursor *cur, void *kdata, size_t kn, void *vdata, size_t vn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
+int lmdbgo_mdb_del(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn);
+int lmdbgo_mdb_get(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val);
+int lmdbgo_mdb_put1(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, MDB_val *val, unsigned int flags);
+int lmdbgo_mdb_put2(MDB_txn *txn, MDB_dbi dbi, char *kdata, size_t kn, char *vdata, size_t vn, unsigned int flags);
+int lmdbgo_mdb_cursor_put1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *val, unsigned int flags);
+int lmdbgo_mdb_cursor_put2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, unsigned int flags);
+int lmdbgo_mdb_cursor_putmulti(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, size_t vstride, unsigned int flags);
+int lmdbgo_mdb_cursor_get1(MDB_cursor *cur, char *kdata, size_t kn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
+int lmdbgo_mdb_cursor_get2(MDB_cursor *cur, char *kdata, size_t kn, char *vdata, size_t vn, MDB_val *key, MDB_val *val, MDB_cursor_op op);
 
 /* ConstCString wraps a null-terminated (const char *) because Go's type system
  * does not represent the 'cosnt' qualifier directly on a function argument and

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -284,7 +284,7 @@ func (txn *Txn) Get(dbi DBI, key []byte) ([]byte, error) {
 	kdata, kn := valBytes(key)
 	ret := C.lmdbgo_mdb_get(
 		txn._txn, C.MDB_dbi(dbi),
-		unsafe.Pointer(&kdata[0]), C.size_t(kn),
+		(*C.char)(unsafe.Pointer(&kdata[0])), C.size_t(kn),
 		txn.val,
 	)
 	err := operrno("mdb_get", ret)
@@ -318,8 +318,8 @@ func (txn *Txn) Put(dbi DBI, key []byte, val []byte, flags uint) error {
 
 	ret := C.lmdbgo_mdb_put2(
 		txn._txn, C.MDB_dbi(dbi),
-		unsafe.Pointer(&key[0]), C.size_t(kn),
-		unsafe.Pointer(&val[0]), C.size_t(vn),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(kn),
+		(*C.char)(unsafe.Pointer(&val[0])), C.size_t(vn),
 		C.uint(flags),
 	)
 	return operrno("mdb_put", ret)
@@ -335,7 +335,7 @@ func (txn *Txn) PutReserve(dbi DBI, key []byte, n int, flags uint) ([]byte, erro
 	txn.val.mv_size = C.size_t(n)
 	ret := C.lmdbgo_mdb_put1(
 		txn._txn, C.MDB_dbi(dbi),
-		unsafe.Pointer(&key[0]), C.size_t(len(key)),
+		(*C.char)(unsafe.Pointer(&key[0])), C.size_t(len(key)),
 		txn.val,
 		C.uint(flags|C.MDB_RESERVE),
 	)
@@ -358,8 +358,8 @@ func (txn *Txn) Del(dbi DBI, key, val []byte) error {
 	vdata, vn := valBytes(val)
 	ret := C.lmdbgo_mdb_del(
 		txn._txn, C.MDB_dbi(dbi),
-		unsafe.Pointer(&kdata[0]), C.size_t(kn),
-		unsafe.Pointer(&vdata[0]), C.size_t(vn),
+		(*C.char)(unsafe.Pointer(&kdata[0])), C.size_t(kn),
+		(*C.char)(unsafe.Pointer(&vdata[0])), C.size_t(vn),
 	)
 	return operrno("mdb_del", ret)
 }


### PR DESCRIPTION
Fixes #63 