### PR TITLE
lmdb: slice pointers without reflect

### DIFF
--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -9,8 +9,14 @@ import "C"
 
 import "unsafe"
 
-// valMaxSize is the largest data sized allowed by lmdb-go.  Luckily, it
-// coincides with the maximum data value for LMDB (MAXDATASIZE).
+// valMaxSize is the largest portable data size allowed by Go (larger can cause
+// an error like "type [...]byte larger than address space").  See runtime
+// source file malloc.go for more information about memory limits.
+//
+//		https://github.com/golang/go/blob/a03bdc3e6bea34abd5077205371e6fb9ef354481/src/runtime/malloc.go#L151-L164
+//
+// Luckily, the value 2^32-1 coincides with the maximum data value for LMDB
+// (MAXDATASIZE).
 const valMaxSize = 1<<32 - 1
 
 // Multi is a wrapper for a contiguous page of sorted, fixed-length values

--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -15,7 +15,7 @@ import "unsafe"
 //
 //		https://github.com/golang/go/blob/a03bdc3e6bea34abd5077205371e6fb9ef354481/src/runtime/malloc.go#L151-L164
 //
-// Luckily, the value 2^32-1 coincides with the maximum data value for LMDB
+// Luckily, the value 2^32-1 coincides with the maximum data size for LMDB
 // (MAXDATASIZE).
 const valMaxSize = 1<<32 - 1
 

--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -7,10 +7,9 @@ package lmdb
 */
 import "C"
 
-import (
-	"reflect"
-	"unsafe"
-)
+import "unsafe"
+
+const valMaxSize = 1<<32 - 1
 
 // Multi is a wrapper for a contiguous page of sorted, fixed-length values
 // passed to Cursor.PutMulti or retrieved using Cursor.Get with the
@@ -96,12 +95,7 @@ func wrapVal(b []byte) *C.MDB_val {
 }
 
 func getBytes(val *C.MDB_val) []byte {
-	hdr := reflect.SliceHeader{
-		Data: uintptr(unsafe.Pointer(val.mv_data)),
-		Len:  int(val.mv_size),
-		Cap:  int(val.mv_size),
-	}
-	return *(*[]byte)(unsafe.Pointer(&hdr))
+	return (*[valMaxSize]byte)(unsafe.Pointer(val.mv_data))[:val.mv_size:val.mv_size]
 }
 
 func getBytesCopy(val *C.MDB_val) []byte {

--- a/lmdb/val.go
+++ b/lmdb/val.go
@@ -9,6 +9,8 @@ import "C"
 
 import "unsafe"
 
+// valMaxSize is the largest data sized allowed by lmdb-go.  Luckily, it
+// coincides with the maximum data value for LMDB (MAXDATASIZE).
 const valMaxSize = 1<<32 - 1
 
 // Multi is a wrapper for a contiguous page of sorted, fixed-length values


### PR DESCRIPTION
Fixes #67 

Uses a temporary conversion from unsafe.Pointer to `*[valMaxSize]byte` to create a slice of the actual data length (and capacity).

edit: It  does not appear to slow anything down. If anything it makes things slightly faster. And it avoids a direct dependency on the "reflect" package.