### PR TITLE
lmdb: add fdatasync and lmdb_debug build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,17 @@ Building commands and running tests can be done with `go` or with `make`
     make check
     make all
 
-On Linux, you can specify the `pwritev` build tag to reduce the number of syscalls
-required when committing a transaction. In your own package you can then do
+There are several build tags you can use to tune the library.
 
-    go build -tags pwritev .
+* `pwritev` (Linux only): reduce the number of syscalls on transaction commit
+* `fdatasync` (Linux only): reduce the amount of data written on transaction commit (only safe on kernels >= 3.6)
+* `lmdb_debug`: enable LMDB debug output
 
-to enable the optimisation.
+In your own package you can then do
+
+    go build -tags pwritev,lmdb_debug .
+
+to enable any of the supported tags. Enabling Linux-only flags on a different OS is a no-op and therefore safe to do.
 
 ##Documentation
 

--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -56,6 +56,8 @@ package lmdb
 /*
 #cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -O2 -g
 #cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
+#cgo linux,fdatasync CFLAGS: -DMDB_FDATASYNC_WORKS
+#cgo lmdb_debug CFLAGS: -DMDB_DEBUG=1
 
 #include "lmdb.h"
 */

--- a/lmdb/mdb.c
+++ b/lmdb/mdb.c
@@ -459,7 +459,7 @@ typedef MDB_ID	txnid_t;
 #endif
 
 #if MDB_DEBUG
-static int mdb_debug;
+static int mdb_debug = 1;
 static txnid_t mdb_debug_start;
 
 	/**	Print a debug message with printf formatting.


### PR DESCRIPTION
Enabling debugging requires a code change in mdb.c: mdb_debug is checked by the DPRINTF call, but never set in the codebase. Set mdb_debug to 1 statically until we figure out what is going on.