### PR TITLE
Cursor.Get handles key return values specicially for Set

### DIFF
--- a/lmdb/cursor_test.go
+++ b/lmdb/cursor_test.go
@@ -297,6 +297,8 @@ func TestCursor_Get_op_Set(t *testing.T) {
 		if err != nil {
 			return err
 		}
+		defer cur.Close()
+
 		k, v, err := cur.Get([]byte("k2"), nil, Set)
 		if err != nil {
 			return err
@@ -307,6 +309,7 @@ func TestCursor_Get_op_Set(t *testing.T) {
 		if string(v) != "v21" {
 			t.Errorf("unexpected value: %q (not %q)", v, "v21")
 		}
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #96

Issue #56 illustrated that working with Go memory using "C-style" memory
does not work well in modern Go runtimes.  That problem was thought to
be properly addressed, but #96 showed a lingering case where Set does
not modify MDB_val key passed to mdb_cursor_get.

This commit addresses this lingering case by special-casing return value
processing for the Set operation of Cursor.Get.  If LMDB will not modify
the MDB_val, the returned key must use non-standard methods for copying
the value.  Likewise, when txn.RawRead is true the Cursor.Get must use a
special method to ensure that the returned key shares memory with the
corresponding input argument.