### PR TITLE
lmdb: Update transactions share C-allocated C.MDB_val objects

### DIFF
--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -62,6 +62,9 @@ type DBI C.MDB_dbi
 // See MDB_env.
 type Env struct {
 	_env *C.MDB_env
+
+	ckey *C.MDB_val
+	cval *C.MDB_val
 }
 
 // NewEnv allocates and initializes a new Env.
@@ -73,6 +76,9 @@ func NewEnv() (*Env, error) {
 	if ret != success {
 		return nil, operrno("mdb_env_create", ret)
 	}
+	env.ckey = (*C.MDB_val)(C.malloc(C.size_t(unsafe.Sizeof(C.MDB_val{}))))
+	env.cval = (*C.MDB_val)(C.malloc(C.size_t(unsafe.Sizeof(C.MDB_val{}))))
+
 	runtime.SetFinalizer(env, (*Env).Close)
 	return env, nil
 }
@@ -157,6 +163,10 @@ func (env *Env) close() bool {
 	}
 	C.mdb_env_close(env._env)
 	env._env = nil
+	C.free(unsafe.Pointer(env.ckey))
+	C.free(unsafe.Pointer(env.cval))
+	env.ckey = nil
+	env.cval = nil
 	return true
 }
 

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -63,17 +63,17 @@ func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
 	var ptxn *C.MDB_txn
 	if parent == nil {
 		if flags&Readonly == 0 {
+			// In a write Txn we can use the shared, C-allocated key and value
+			// allocated by env, and freed when it is closed.
+			txn.key = env.ckey
+			txn.val = env.cval
+		} else {
 			// It is not easy to share C.MDB_val values in this scenario unless
 			// there is a synchronized pool involved, which will increase
 			// overhead.  Further, allocating these values with C will add
 			// overhead both here and when the values are freed.
 			txn.key = new(C.MDB_val)
 			txn.val = new(C.MDB_val)
-		} else {
-			// In a write Txn we can use the shared, C-allocated key and value
-			// allocated by env, and freed when it is closed.
-			txn.key = env.ckey
-			txn.val = env.cval
 		}
 	} else {
 		// Because parent Txn objects cannot be used while a sub-Txn is active

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -62,10 +62,22 @@ func beginTxn(env *Env, parent *Txn, flags uint) (*Txn, error) {
 
 	var ptxn *C.MDB_txn
 	if parent == nil {
-		ptxn = nil
-		txn.key = new(C.MDB_val)
-		txn.val = new(C.MDB_val)
+		if flags&Readonly == 0 {
+			// It is not easy to share C.MDB_val values in this scenario unless
+			// there is a synchronized pool involved, which will increase
+			// overhead.  Further, allocating these values with C will add
+			// overhead both here and when the values are freed.
+			txn.key = new(C.MDB_val)
+			txn.val = new(C.MDB_val)
+		} else {
+			// In a write Txn we can use the shared, C-allocated key and value
+			// allocated by env, and freed when it is closed.
+			txn.key = env.ckey
+			txn.val = env.cval
+		}
 	} else {
+		// Because parent Txn objects cannot be used while a sub-Txn is active
+		// it is OK for them to share their C.MDB_val objects.
 		ptxn = parent._txn
 		txn.key = parent.key
 		txn.val = parent.val


### PR DESCRIPTION
Update transactions must execute exclusively and it is OK for these
transactions to share two C.MDB_val object that are alive for entire
existence of the Env object.

View transactions cannot use these C.MDB_val objects because they may
execute concurrently with other View transactions or an Update
transaction.