### PR TITLE
Keep finalizer on Txn.Reset and address incompatibilities of Txn and sync.Pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ A utility package for scanning database ranges. The API is inspired by
 [bufio.Scanner](https://godoc.org/bufio#Scanner) and the python cursor
 [implementation](https://lmdb.readthedocs.org/en/release/#cursor-class).
 
+####exp/lmdbpool [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbpool) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability) [![GoCover](http://gocover.io/_badge/github.com/bmatsuo/lmdb-go/exp/lmdbpool)](http://gocover.io/github.com/bmatsuo/lmdb-go/exp/lmdbpool)
+
+
+```go
+import "github.com/bmatsuo/lmdb-go/exp/lmdbpool"
+```
+
+A utility package which facilitates reuse of lmdb.Txn objects using a
+sync.Pool.  Naively storing lmdb.Txn objects in sync.Pool can be troublesome.
+And the lmdbpool.TxnPool type has been defined as a complete pooling solution
+and as reference for applications attempting to write their own pooling
+implementation.
+
+The lmdbpool package is relatively new.  But it has a lot of potential utility.
+And once the lmdbpool API has been ironed out, and the implementation hardened
+through use by real applications it can be integrated directly into the lmdb
+package for more transparent integration.  Please test this package and provide
+feedback to speed this process up.
+
 ####exp/lmdbsync [![GoDoc](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync?status.svg)](https://godoc.org/github.com/bmatsuo/lmdb-go/exp/lmdbsync) [![experimental](https://img.shields.io/badge/stability-experimental-red.svg)](#user-content-versioning-and-stability) [![GoCover](http://gocover.io/_badge/github.com/bmatsuo/lmdb-go/exp/lmdbsync)](http://gocover.io/github.com/bmatsuo/lmdb-go/exp/lmdbsync)
 
 

--- a/exp/lmdbpool/doc.go
+++ b/exp/lmdbpool/doc.go
@@ -20,9 +20,9 @@ the environment at initialization time.
 	err := env.SetMaxReaders(maxReaders)
 
 In a naive pooling implementation an application compiled with the -race flag
-may require a large number of open readers.  The TxnPool type attempts to keep
-the value required for Env.SetMaxReaders as low as possible in the presence of
--race but there is a limited amount that can be done for a concurrent workload
-with a rapid enough rate of transactions.
+may require an extremely large number of open readers.  The TxnPool type
+attempts to keep the value required for Env.SetMaxReaders as low as possible in
+the presence of -race but there is a limited amount that can be done for a
+concurrent workload with a rapid enough rate of transactions.
 */
 package lmdbpool

--- a/exp/lmdbpool/doc.go
+++ b/exp/lmdbpool/doc.go
@@ -1,0 +1,28 @@
+/*
+Package lmdbpool provides a TxnPool type that allows lmdb.Readonly transactions
+to safely be reused by other goroutines when the goroutine that created the
+transaction no longer has a use for it.  The TxnPool type has benefits that
+would be absent in a naive use of sync.Pool with lmdb.Txn types.
+
+Naively reusing lmdb.Readonly transactions can cause updates to continually
+allocate more pages for the database instead of reusing stale pages.  The
+TxnPool type tracks transaction ids to make sure that lmdb.Readonly
+transactions are not reused when they are known to be holding stale pages which
+could be reclaimed by LMDB.
+
+A general downside of pooling lmdb.Readonly transactions using a sync.Pool in
+applications with a very high rate of transacions is that the number of readers
+in an environment can be significantly higher than the number of goroutines
+actively trying to read from that environment.  Because of this it is possible
+that applications may need to increase the maximum number of readers allowed in
+the environment at initialization time.
+
+	err := env.SetMaxReaders(maxReaders)
+
+In a naive pooling implementation an application compiled with the -race flag
+may require a large number of open readers.  The TxnPool type attempts to keep
+the value required for Env.SetMaxReaders as low as possible in the presence of
+-race but there is a limited amount that can be done for a concurrent workload
+with a rapid enough rate of transactions.
+*/
+package lmdbpool

--- a/exp/lmdbpool/put.go
+++ b/exp/lmdbpool/put.go
@@ -1,0 +1,12 @@
+// +build !race
+
+package lmdbpool
+
+// In general we want Txn objects to be returned to the sync.Pool. But because
+// the default behavior of Pool.Put during race detection is to drop everything
+// on the floor.  This isn't the end of world, but if the Txn finalizers don't
+// don't run fast enough you can end up hitting the environment's limit on
+// readers.  This is still not terrible unless you run your benchmarks with
+// race detection enabled.  In such cases benchmarks issuing repeated reads
+// will quickly blow the environments reader limit.
+const returnTxnToPool = true

--- a/exp/lmdbpool/putrace.go
+++ b/exp/lmdbpool/putrace.go
@@ -1,0 +1,12 @@
+//+build race
+
+package lmdbpool
+
+// transactions abort immediately instead of "being put in the pool" when race
+// detection is enabled to prevent benchmarks with race enabled from forcing
+// applications to allow ridiculously large maximum numbers of readers.
+//
+// As of go1.8 the sync.Pool implementation never reuses objects during race
+// detection.  The special logic which bypasses this requires a similar bypass
+// here, unfortunately.
+const returnTxnToPool = false

--- a/exp/lmdbpool/txnpool.go
+++ b/exp/lmdbpool/txnpool.go
@@ -1,0 +1,173 @@
+package lmdbpool
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"sync/atomic"
+
+	"github.com/bmatsuo/lmdb-go/lmdb"
+)
+
+// TxnPool is a pool for reusing transactions through their Reset and Renew
+// methods.  However, even though TxnPool can only reuse lmdb.Readonly
+// transactions it this way it should be used to create and terminate all Txns
+// if it is used at all.  Update transactions can cause LMDB to use excessive
+// numbers of pages when there are long-lived lmdb.Readonly transactions in a
+// TxnPool.  Executing all transactions using the TxnPool allows it to track
+// updates and prevent long-lived updates from causing excessive disk
+// utilization.
+type TxnPool struct {
+	env    *lmdb.Env
+	lastid uintptr
+	pool   sync.Pool
+}
+
+// NewTxnPool initializes returns a new TxnPool.
+func NewTxnPool(env *lmdb.Env) *TxnPool {
+	p := &TxnPool{
+		env: env,
+	}
+	return p
+}
+
+// Close flushes the pool of transactions and aborts them to free resources so
+// that the pool Env may be closed.
+func (p *TxnPool) Close() {
+	txn, ok := (*lmdb.Txn)(nil), true
+	for ok {
+		txn, ok = p.pool.Get().(*lmdb.Txn)
+		if ok {
+			txn.Abort()
+		}
+	}
+}
+
+// BeginTxn is analogous to the BeginTxn method on lmdb.Env but may only be
+// used to create lmdb.Readonly transactions.  Any call to BeginTxn that does
+// not include lmdb.Readonly will return an error
+func (p *TxnPool) BeginTxn(flags uint) (*lmdb.Txn, error) {
+	// We can only re-use transactions with exactly the same flags.  So
+	// instead of masking flags with lmdb.Readonly an equality comparison
+	// is necessary.
+	if flags != lmdb.Readonly {
+		return nil, fmt.Errorf("flag lmdb.Readonly not provided")
+	}
+
+	return p.beginReadonly()
+}
+
+func (p *TxnPool) beginReadonly() (*lmdb.Txn, error) {
+	txn, ok := p.pool.Get().(*lmdb.Txn)
+	if !ok {
+		return p.env.BeginTxn(nil, lmdb.Readonly)
+	}
+
+	// Abort the pooled transaction if it is causing LMDB to hold onto old
+	// pages.
+	id := txn.ID()
+	lastid := atomic.LoadUintptr(&p.lastid)
+	if id < lastid {
+		txn.Abort()
+
+		// Beginning a new transaction without continuing to read from the pool
+		// is lazy.  But it is likely that remaining Txn objects in the pool
+		// are holding stale pages and polling them out would be slow.
+		// Instead, we hope the Txn finalizer will pick them up before any
+		// other caller would.
+		return p.env.BeginTxn(nil, lmdb.Readonly)
+	}
+
+	err := txn.Renew()
+	if err != nil {
+		txn.Abort()
+		log.Printf("lmdbpool: failed to renew transaction: %v", err)
+
+		// It's not clear for now what better handling of a renew error would
+		// be so we just try to create a new transaction.  Presumably it will
+		// fail with the same error.
+		return p.env.BeginTxn(nil, lmdb.Readonly)
+	}
+
+	// Clear txn.Pooled to let a warning be emitted from the Txn finalizer
+	// again.  And, make sure to clear RawRead to make the Txn appear like it
+	// was just allocated.
+	txn.RawRead = false
+	txn.Pooled = false
+
+	return txn, nil
+}
+
+func (p *TxnPool) abortReadonly(txn *lmdb.Txn) {
+	// Don't waste cycles resetting RawRead here -- the cost be paid when the
+	// Txn is reused (if at all).  All we need to do is set txn.Pooled to avoid
+	// any warning emitted from the Txn finalizer.
+	txn.Pooled = true
+
+	txn.Reset()
+	if returnTxnToPool {
+		p.pool.Put(txn)
+	} else {
+		// If the pool is disabled from race detection then we just abort the
+		// Txn instead of waiting for the finalizer.  See the files put.go and
+		// putrace.go for more information.
+		txn.Abort()
+	}
+}
+
+// CommitID sets the TxnPool's last-known transaction id to invalidate
+// previously created lmdb.Readonly transactions and prevent their reuse.
+//
+// CommitID should only be called if p is not used to create/commit update
+// transactions.
+func (p *TxnPool) CommitID(id uintptr) {
+	// As long as we think we are holding a newer id than lastid we keep trying
+	// to CAS until we see a newer id or the CAS succeeds.
+	lastid := atomic.LoadUintptr(&p.lastid)
+	for lastid < id && !atomic.CompareAndSwapUintptr(&p.lastid, lastid, id) {
+		lastid = atomic.LoadUintptr(&p.lastid)
+	}
+}
+
+// Abort aborts the txn and allows it to be reused if possible.  Abort must
+// only be passed lmdb.Txn objects which it returned from a call to BeginTxn.
+// Aborting a transaction created through other means will have undefined
+// results.
+func (p *TxnPool) Abort(txn *lmdb.Txn) {
+	p.abortReadonly(txn)
+}
+
+// Update is analogous to the Update method on lmdb.Env.
+func (p *TxnPool) Update(fn lmdb.TxnOp) error {
+	var id uintptr
+	err := p.env.Update(func(txn *lmdb.Txn) (err error) {
+		err = fn(txn)
+		if err != nil {
+			return err
+		}
+
+		// Save the transaction identifier once we know fn succeeded so that
+		// the p.lastid field can be set appropriately once the txn has
+		// committed successfully.
+		id = txn.ID()
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	p.CommitID(id)
+
+	return nil
+}
+
+// View is analogous to the View method on lmdb.Env.
+func (p *TxnPool) View(fn lmdb.TxnOp) error {
+	txn, err := p.beginReadonly()
+	if err != nil {
+		return err
+	}
+	defer p.abortReadonly(txn)
+	return txn.RunOp(fn, false)
+}

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -508,13 +508,7 @@ func (env *Env) run(lock bool, flags uint, fn TxnOp) error {
 	if err != nil {
 		return err
 	}
-	txn.managed = true
-	defer txn.abort()
-	err = fn(txn)
-	if err != nil {
-		return err
-	}
-	return txn.commit()
+	return txn.RunOp(fn, true)
 }
 
 // CloseDBI closes the database handle, db.  Normally calling CloseDBI


### PR DESCRIPTION
Fixes #104 

In addition to removing the undocumented finalizer behavior in Txn.Reset and Txn.Renew which, as #104 points out, was never a good idea or a safe one. I have gone on to try and ensure that lmdb.Txn and sync.Pool can be used together effectively (to whatever extent that is truly possible).

There are some questions about how sync.Pool and lmdb.Txn truly interact, mostly because of how poorly defined finalizers are. In testing it has been seen that naive pooling fails terribly if the application has been compiled with `-race`. The interaction with `-race` was so bad that it spurred the creation of a new experimental package lmdbpool, which contains a workaround for race detection using build tags.

At this point I'm not completely certain if there are unforeseen problems in interactions between sync.Pool, finalizers, the Go runtime, and cgo. But as far as I have been able to tell the only potential downside is an excess of pages being used. But my understanding of LMDB makes me believe it is possible to benefit from pooling while tracking which transactions would cause LMDB to retain stale pages and keeping such pages to a minimum (not significantly more stale pages than an application without pooling would generate).

So, I am willing to provide the lmdbpool package as an 'experimental' package included in the lmdb-go project until its use is shown to be truly and unavoidably unsafe. If the lmdbpool package proves to be successful with enough benefits then it can be rolled into the core lmdb package for more direct/transparent integration.