### PR TITLE
lmdb: Silence missing initializers error on clang

### DIFF
--- a/lmdb/lmdb.go
+++ b/lmdb/lmdb.go
@@ -84,7 +84,7 @@ details about dealing with such situations.
 package lmdb
 
 /*
-#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -O2 -g
+#cgo CFLAGS: -pthread -W -Wall -Wno-unused-parameter -Wno-format-extra-args -Wbad-function-cast -Wno-missing-field-initializers -O2 -g
 #cgo linux,pwritev CFLAGS: -DMDB_USE_PWRITEV
 
 #include "lmdb.h"


### PR DESCRIPTION
Compiling this package on clang currently generates the following bogus warnings:

    $ go test ./lmdb
    # github.com/bmatsuo/lmdb-go/lmdb
    lmdb/mdb.c:9100:20: warning: missing field 'mc_backup' initializer [-Wmissing-field-initializers]
    lmdb/mdb.c:9258:18: warning: missing field 'mc_txn' initializer [-Wmissing-field-initializers]
    ok      github.com/bmatsuo/lmdb-go/lmdb    0.380s

Add a flag to the CGO implementation which suppresses this output. See https://bugs.llvm.org//show_bug.cgi?id=21689 for the upstream bug.