### PR TITLE
lmdb: Txn.RunOp splits into two implementations based on termination

### DIFF
--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -508,7 +508,7 @@ func (env *Env) run(lock bool, flags uint, fn TxnOp) error {
 	if err != nil {
 		return err
 	}
-	return txn.RunOp(fn, true)
+	return txn.runOpCommit(fn)
 }
 
 // CloseDBI closes the database handle, db.  Normally calling CloseDBI

--- a/lmdb/env.go
+++ b/lmdb/env.go
@@ -508,7 +508,7 @@ func (env *Env) run(lock bool, flags uint, fn TxnOp) error {
 	if err != nil {
 		return err
 	}
-	return txn.runOpCommit(fn)
+	return txn.runOpTerm(fn)
 }
 
 // CloseDBI closes the database handle, db.  Normally calling CloseDBI

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -111,10 +111,10 @@ func (txn *Txn) ID() uintptr {
 // about txn if fn returns an error.
 //
 // RunOp primarily exists to allow applications and other packages to provide
-// variants on the managed transactions provided by lmdb in View, Update, etc.
-// For example, the lmdbpool package uses RunOp to provide an Txn-friendly
-// sync.Pool and a function analogous to Env.View that uses transactions from
-// that pool.
+// variants of the managed transactions provided by lmdb (i.e. View, Update,
+// etc).  For example, the lmdbpool package uses RunOp to provide an
+// Txn-friendly sync.Pool and a function analogous to Env.View that uses
+// transactions from that pool.
 func (txn *Txn) RunOp(fn TxnOp, commit bool) error {
 	if commit {
 		return txn.runOpCommit(fn)

--- a/lmdb/txn.go
+++ b/lmdb/txn.go
@@ -105,10 +105,16 @@ func (txn *Txn) ID() uintptr {
 	return uintptr(C.mdb_txn_id(txn._txn))
 }
 
-// RunOp executs fn with txn as an argument.  During the execution of fn no
+// RunOp executes fn with txn as an argument.  During the execution of fn no
 // goroutine may call the Commit, Abort, Reset, and Renew methods on txn.
 // RunOp returns the result of fn without any further action.  RunOp will not
 // about txn if fn returns an error.
+//
+// RunOp primarily exists to allow applications and other packages to provide
+// variants on the managed transactions provided by lmdb in View, Update, etc.
+// For example, the lmdbpool package uses RunOp to provide an Txn-friendly
+// sync.Pool and a function analogous to Env.View that uses transactions from
+// that pool.
 func (txn *Txn) RunOp(fn TxnOp, commit bool) error {
 	if commit {
 		return txn.runOpCommit(fn)


### PR DESCRIPTION
This is fairly convenient because it is a reasonably fast path for the
most common managed transactions.

Also, this addition will properly panic when `commit` is supplied from a managed transaction, which was a bug in the previous implementation.