### PR TITLE
Rework BenchmarkScan to benchmark Txn.Renew

### DIFF
--- a/lmdb/bench_test.go
+++ b/lmdb/bench_test.go
@@ -273,7 +273,7 @@ func BenchmarkTxn_Get_raw_ro(b *testing.B) {
 
 const benchmarkScanDBSize = 1 << 20
 
-func BenchmarkScan_rw_copy_alloc(b *testing.B) {
+func BenchmarkScan_alloc_rw_copy(b *testing.B) {
 	env := setup(b)
 	defer clean(env, b)
 
@@ -307,7 +307,7 @@ func BenchmarkScan_rw_copy_alloc(b *testing.B) {
 	}
 }
 
-func BenchmarkScan_rw_raw_alloc(b *testing.B) {
+func BenchmarkScan_alloc_rw_raw(b *testing.B) {
 	env := setup(b)
 	defer clean(env, b)
 
@@ -344,7 +344,7 @@ func BenchmarkScan_rw_raw_alloc(b *testing.B) {
 }
 
 // repeatedly scan all the values in a database.
-func BenchmarkScan_ro_copy_alloc(b *testing.B) {
+func BenchmarkScan_alloc_ro_copy(b *testing.B) {
 	env := setup(b)
 	defer clean(env, b)
 
@@ -379,7 +379,7 @@ func BenchmarkScan_ro_copy_alloc(b *testing.B) {
 }
 
 // like BenchmarkCursoreScanReadonly but txn.RawRead is set to true.
-func BenchmarkScan_ro_raw_alloc(b *testing.B) {
+func BenchmarkScan_alloc_ro_raw(b *testing.B) {
 	env := setup(b)
 	defer clean(env, b)
 
@@ -416,7 +416,7 @@ func BenchmarkScan_ro_raw_alloc(b *testing.B) {
 }
 
 // like BenchmarkCursoreScanReadonly but txn.RawRead is set to true.
-func BenchmarkScan_ro_raw_renew(b *testing.B) {
+func BenchmarkScan_renew_ro_raw(b *testing.B) {
 	env := setup(b)
 	defer clean(env, b)
 

--- a/lmdb/bench_test.go
+++ b/lmdb/bench_test.go
@@ -3,7 +3,6 @@ package lmdb
 import (
 	crand "crypto/rand"
 	"math/rand"
-	"os"
 	"sync/atomic"
 	"testing"
 )
@@ -399,11 +398,6 @@ func openBenchDBI(b *testing.B, env *Env) DBI {
 		b.Errorf("unable to open benchmark database")
 	}
 	return dbi
-}
-
-func teardownBenchDB(b *testing.B, env *Env, path string) {
-	env.Close()
-	os.RemoveAll(path)
 }
 
 func randBytes(n int) []byte {


### PR DESCRIPTION
It is not obvious that an update transaction will be faster than a
Readonly transaction, even when renewing both the Txn and Cursor object.
This benchmark rework is the first in a series that I hope to make, and
that I hope will continue to bring meaningful insight into LMDB
performance, unlike many of the existing benchmarks.