### PR TITLE
lmdbpool: Improvements to TxnPool

### DIFF
--- a/exp/lmdbpool/txnpool.go
+++ b/exp/lmdbpool/txnpool.go
@@ -50,10 +50,14 @@ const (
 // updates and prevent long-lived updates from causing excessive disk
 // utilization.
 type TxnPool struct {
+	// UpdateHandling determines how a TxnPool behaves after updates have been
+	// committed.  It is not safe to modify UpdateHandling if TxnPool is being
+	// used concurrently.
 	UpdateHandling UpdateHandling
-	env            *lmdb.Env
-	lastid         uintptr
-	pool           sync.Pool
+
+	lastid uintptr
+	env    *lmdb.Env
+	pool   sync.Pool
 }
 
 // NewTxnPool initializes returns a new TxnPool.

--- a/exp/lmdbpool/txnpool.go
+++ b/exp/lmdbpool/txnpool.go
@@ -92,7 +92,7 @@ func (p *TxnPool) beginReadonly() (*lmdb.Txn, error) {
 	// LMDB documentation as of 0.9.19).
 	err := txn.Renew()
 	if err != nil {
-		txn.renewError(err)
+		p.renewError(err)
 
 		// Nothing we can do with txn now other than destroy it.
 		txn.Abort()

--- a/lmdb/txn_test.go
+++ b/lmdb/txn_test.go
@@ -15,9 +15,13 @@ func TestTxn_ID(t *testing.T) {
 	env := setup(t)
 	defer clean(env, t)
 
-	var id1, id2, id3 uintptr
+	var id0, id1, id2, id3 uintptr
 	var txnInvalid *Txn
-	err := env.Update(func(txn *Txn) (err error) {
+	err := env.View(func(txn *Txn) (err error) {
+		id0 = txn.ID()
+		return nil
+	})
+	err = env.Update(func(txn *Txn) (err error) {
 		dbi, err := txn.OpenRoot(0)
 		if err != nil {
 			return err
@@ -39,13 +43,17 @@ func TestTxn_ID(t *testing.T) {
 		return
 	}
 	id3 = txnInvalid.ID()
+	t.Logf("ro txn id:: %v", id1)
 	t.Logf("txn id: %v", id1)
 	t.Logf("ro txn id: %v", id2)
 	t.Logf("bad txn id: %v", id3)
+	if 0 != id0 {
+		t.Errorf("unexpected readonly id (before update): %v (!= %v)", id0, 0)
+	}
 	if id1 != id2 {
 		t.Errorf("unexpected readonly id: %v (!= %v)", id2, id1)
 	}
-	if id2 == id3 {
+	if 0 != id3 {
 		t.Errorf("unexpected invalid id: %v (!= %v)", id3, 0)
 	}
 }


### PR DESCRIPTION
Checking of Txn.ID() for lmdb.Readonly transactions now occurs at the correct location (as a Txn would enter the pool as opposed to when it exits the pool).

There is also an optimization that allows Txn.ID() to cache the value it gets for future calls. This requires some bookkeeping because there are times when a transaction's ID may change. But the logic behind this in LMDB is straight forward and there are some tests to make sure that Txn.ID() does transparently represent the value returned by `mdb_txn_id`.