### PR TITLE
lmdbpool: TxnPool.CommitID handles idle transactions in the pool

### DIFF
--- a/exp/lmdbpool/txnpool.go
+++ b/exp/lmdbpool/txnpool.go
@@ -208,6 +208,7 @@ func (p *TxnPool) CommitID(id uintptr) {
 	for lastid < id {
 		if atomic.CompareAndSwapUintptr(&p.lastid, lastid, id) {
 			updated = true
+			break
 		}
 		lastid = atomic.LoadUintptr(&p.lastid)
 	}


### PR DESCRIPTION
A new goroutine is spawned for each update.  This may turn out to be too
costly.  We want updates to complete as fast as possible and handling
the idle transactions in that goroutine is not practical.  So it really
just comes down to doing things this way or using a permanent working
goroutine that would require more management/bookkeeping.