### PR TITLE
use project license

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,5 +55,5 @@ contributors to follow.
     errors from `go test`, `go vet`, or `golint`.
 
 By submitting a pull request for this project, you are asserting that you have
-the rights to provide it and agree to license your contribution under the MIT
+the rights to provide it and agree to license your contribution under the BSD-3
 license to this project.


### PR DESCRIPTION
Shouldn't the license here be better BSD-3 instead of MIT?